### PR TITLE
upgrade upstream

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: grafana/oats
-          ref: 9f52416d55be4a8d009d9143b2a3771f9fc77b19
+          ref: 911c5f7c47ba3fb3b8ed35ffdd5bcac36cce62f4
           path: oats
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: grafana/oats
-          ref: 911c5f7c47ba3fb3b8ed35ffdd5bcac36cce62f4
+          ref: d2e59f9857d898f9d0f606714de3b22ee9d61804
           path: oats
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+                     
+## 0.32.0-beta.1 (2023-11-22)
+
+- Update to OpenTelemetry 1.32.0
+- **Breaking Change**: Use new [JVM semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/)
+- **Breaking Change**: Use `telemetry.distro.name` = `grafana-opentelemetry-java` 
+  and `telemetry.distro.version` = `0.32.0-beta.1` to identify this distribution instead of 
+  `telemetry.sdk.name` = `grafana-opentelemetry-java` and `telemetry.sdk.version` = `0.32.0`
+  (for reference: from now on `telemetry.sdk.name` = `opentelemetry` and `telemetry.sdk.version` = `1.32.0`.
 
 ## 0.31.0 (2023-11-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
-                     
+
 ## 0.32.0-beta.1 (2023-11-22)
 
 - Update to OpenTelemetry 1.32.0
 - **Breaking Change**: Use new [JVM semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/)
-- **Breaking Change**: Use `telemetry.distro.name` = `grafana-opentelemetry-java` 
-  and `telemetry.distro.version` = `0.32.0-beta.1` to identify this distribution instead of 
+- **Breaking Change**: Use `telemetry.distro.name` = `grafana-opentelemetry-java`
+  and `telemetry.distro.version` = `0.32.0-beta.1` to identify this distribution instead of
   `telemetry.sdk.name` = `grafana-opentelemetry-java` and `telemetry.sdk.version` = `0.32.0`
   (for reference: from now on `telemetry.sdk.name` = `opentelemetry` and `telemetry.sdk.version` = `1.32.0`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV OTEL_SERVICE_NAME=<Service Name>
 #     - Click on "Application"
 # Note: It might take up to five minutes for data to appear.
 
-ARG version=0.31.0
+ARG version=0.32.0-beta.1
 WORKDIR /app/
 
 # use a fixed version

--- a/README.md
+++ b/README.md
@@ -267,16 +267,17 @@ If the application is sending data to a [Grafana Agent] or [OpenTelemetry Collec
 ### Enable debug logging in javaagent
 
 To turn on the javaagent's internal debug logging:
-                   
+
 ```shell
 export OTEL_JAVAAGENT_DEBUG=true
 ```
 
-**Note:** These logs are extremely verbose. Enable debug logging only when needed. Debug logging negatively impacts the performance of your application.
+**Note:** These logs are extremely verbose. Enable debug logging only when needed.
+Debug logging negatively impacts the performance of your application.
 
 ### Disable javaagent
 
-If your service causes errors, and you want to check if it's because of a bug in the java agent, 
+If your service causes errors, and you want to check if it's because of a bug in the java agent,
 you can disable the java completely:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Why use this distribution instead of [OpenTelemetry Instrumentation for Java] (u
 > - You can migrate from this distribution to OpenTelemetry Instrumentation for Java as explained
 >   [here](#migrating-to-opentelemetry-instrumentation-for-java).
 
+## Community
+
+To engage with the Grafana Cloud Application Observability community:
+
+- Chat with us on our community Slack channel. To invite yourself to the
+  Grafana Slack, visit [https://slack.grafana.com/](https://slack.grafana.com)
+  and join the [#application-observability](https://grafana.slack.com/archives/C05E87XRK3J)
+channel.
+- Ask questions on the [Discussions page](https://github.com/grafana/grafana-opentelemetry-java/discussions).
+- [File an issue](https://github.com/grafana/grafana-opentelemetry-java/issues/new)
+  for bugs, enhancements, and feature suggestions.
+
 ## Compatibility
 
 - Java 8+
@@ -229,7 +241,7 @@ Make a few requests to the service to make sure it sends data to Grafana Cloud.
 
 ### Be Patient
 
-Even after you've made a few requests, it can take a couple of minutes
+Even after you've made a few requests, it can take up to 5 minutes
 until the data is visible in Application Observability.
 
 ### Look for errors
@@ -242,8 +254,8 @@ A 5xx response code means that there's something wrong with the [Grafana Cloud O
 
 ### Log all sent telemetry data
 
-If there are not errors in the logs, make sure that the application is actually sending data all using
-[debug logging](#enable-debug-logging).
+If there are no errors in the logs, make sure that the application is actually sending data all using
+[debug logging](#enable-otlp-debug-logging).
 If the application is not sending data, the java agent was probably not loaded - look for the `-javaagent` command line
 parameter.
 
@@ -252,23 +264,24 @@ parameter.
 If the application is sending data to a [Grafana Agent] or [OpenTelemetry Collector] instead of
 [Grafana Cloud OTLP Gateway], make sure that there is no error forwarding the telemetry data.
 
-### OpenTelemetry Instrumentation for Java troubleshooting guide
+### Enable debug logging in javaagent
 
-Finally, there is the
-[troubleshooting guide](https://github.com/open-telemetry/opentelemetry-java-instrumentation#troubleshooting)
-of the upstream OpenTelemetry Instrumentation for Java.
+To turn on the javaagent's internal debug logging:
+                   
+```shell
+export OTEL_JAVAAGENT_DEBUG=true
+```
 
-## Community
+**Note:** These logs are extremely verbose. Enable debug logging only when needed. Debug logging negatively impacts the performance of your application.
 
-To engage with the Grafana Cloud Application Observability community:
+### Disable javaagent
 
-- Chat with us on our community Slack channel. To invite yourself to the
-  Grafana Slack, visit [https://slack.grafana.com/](https://slack.grafana.com)
-  and join the [#application-observability](https://grafana.slack.com/archives/C05E87XRK3J)
-channel.
-- Ask questions on the [Discussions page](https://github.com/grafana/grafana-opentelemetry-java/discussions).
-- [File an issue](https://github.com/grafana/grafana-opentelemetry-java/issues/new)
-  for bugs, enhancements, and feature suggestions.
+If your service causes errors, and you want to check if it's because of a bug in the java agent, 
+you can disable the java completely:
+
+```shell
+export OTEL_JAVAAGENT_ENABLED=false
+```
 
 ## Reference
 
@@ -277,7 +290,7 @@ channel.
   which will take precedence.
 - All exporters are set to `otlp` by default (even the logs exporter).
 
-### Enable Debug Logging
+### Enable OTLP Debug Logging
 
 Log all metrics, traces, and logs that are created for debugging purposes (in addition to sending them to the backend
 via OTLP).
@@ -403,8 +416,6 @@ export OTEL_INSTRUMENTATION_MICROMETER_BASE_TIME_UNIT=s
 export OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_LOG_ATTRIBUTES=true
 export OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_LOG_ATTRIBUTES=true 
 ```
-
---
 
 [OpenTelemetry Instrumentation for Java]: https://github.com/open-telemetry/opentelemetry-java-instrumentation
 [Grafana Cloud Application Observability]: https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/

--- a/README.md
+++ b/README.md
@@ -374,23 +374,23 @@ export GRAFANA_OTEL_APPLICATION_OBSERVABILITY_METRICS=true
 
 The following metrics are currently (or planned to be) used by Application Observability:
 
-| Metric                                     | Description                                                            |
-|--------------------------------------------|------------------------------------------------------------------------|
-| process.runtime.jvm.system.cpu.utilization | Used in the JVM tab in Application Observability                       |
-| process.runtime.jvm.memory.usage           | Used in the JVM tab in Application Observability                       |
-| process.runtime.jvm.memory.limit           | Used in the JVM tab in Application Observability                       |
-| process.runtime.jvm.gc.duration            | Used in the JVM tab in Application Observability                       |
-| process.runtime.jvm.classes.current_loaded | Used in the JVM tab in Application Observability                       |
-| process.runtime.jvm.threads.count          | Used in the JVM tab in Application Observability                       |
-| db.client.connections.usage                | Used in [JDBC dashboard](https://grafana.com/grafana/dashboards/19732) |
-| db.client.connections.max                  | Used in [JDBC dashboard](https://grafana.com/grafana/dashboards/19732) |
-| db.client.connections.pending_requests     | Used in [JDBC dashboard](https://grafana.com/grafana/dashboards/19732) |
-| r2dbc.pool.acquired                        | Used by [reactive Database example](examples/jdbc/README.md)           |
-| r2dbc.pool.max.allocated                   | Used by [reactive Database example](examples/jdbc/README.md)           |
-| r2dbc.pool.pending                         | Used by [reactive Database example](examples/jdbc/README.md)           |
-| kafka.producer.record_error_total          | Used by [Kafka example](examples/kafka/README.md)                      |
-| mongodb.driver.pool.waitqueuesize          | Used by [MongoDB example](examples/mongodb/README.md)                  |
-| mongodb.driver.pool.checkedout             | Used by [MongoDB example](examples/mongodb/README.md)                  |
+| Metric                                 | Description                                                            |
+|----------------------------------------|------------------------------------------------------------------------|
+| jvm.cpu.recent_utilization             | Used in the JVM tab in Application Observability                       |
+| jvm.memory.used                        | Used in the JVM tab in Application Observability                       |
+| jvm.memory.limit                       | Used in the JVM tab in Application Observability                       |
+| jvm.gc.duration                        | Used in the JVM tab in Application Observability                       |
+| jvm.class.count                        | Used in the JVM tab in Application Observability                       |
+| jvm.thread.count                       | Used in the JVM tab in Application Observability                       |
+| db.client.connections.usage            | Used in [JDBC dashboard](https://grafana.com/grafana/dashboards/19732) |
+| db.client.connections.max              | Used in [JDBC dashboard](https://grafana.com/grafana/dashboards/19732) |
+| db.client.connections.pending_requests | Used in [JDBC dashboard](https://grafana.com/grafana/dashboards/19732) |
+| r2dbc.pool.acquired                    | Used by [reactive Database example](examples/jdbc/README.md)           |
+| r2dbc.pool.max.allocated               | Used by [reactive Database example](examples/jdbc/README.md)           |
+| r2dbc.pool.pending                     | Used by [reactive Database example](examples/jdbc/README.md)           |
+| kafka.producer.record_error_total      | Used by [Kafka example](examples/kafka/README.md)                      |
+| mongodb.driver.pool.waitqueuesize      | Used by [MongoDB example](examples/mongodb/README.md)                  |
+| mongodb.driver.pool.checkedout         | Used by [MongoDB example](examples/mongodb/README.md)                  |
 
 ### Migrating to OpenTelemetry Instrumentation for Java
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ version '0.31.0'
 
 buildscript {
   ext {
-    otelVersion = "1.31.0"
+    otelVersion = "1.32.0"
   }
   repositories {
     maven {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.grafana'
-version '0.31.0'
+version '0.32.0-beta.1'
 
 buildscript {
   ext {

--- a/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
@@ -28,7 +28,7 @@ public class GrafanaAutoConfigCustomizerProvider implements AutoConfigurationCus
 
   private static Map<String, String> getDefaultProperties() {
     HashMap<String, String> map = new HashMap<>();
-    map.put("otel.semconv-stability.opt-in", "http");
+    map.put("otel.semconv-stability.opt-in", "http,jvm");
     map.put("otel.instrumentation.micrometer.base-time-unit", "s");
     map.put("otel.instrumentation.log4j-appender.experimental-log-attributes", "true");
     map.put("otel.instrumentation.logback-appender.experimental-log-attributes", "true");

--- a/custom/src/main/java/com/grafana/extensions/filter/DefaultMetrics.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/DefaultMetrics.java
@@ -14,12 +14,12 @@ public class DefaultMetrics {
 
   public static final List<String> DEFAULT_METRICS =
       Arrays.asList(
-          "process.runtime.jvm.system.cpu.utilization",
-          "process.runtime.jvm.memory.usage",
-          "process.runtime.jvm.memory.limit",
-          "process.runtime.jvm.gc.duration",
-          "process.runtime.jvm.classes.current_loaded",
-          "process.runtime.jvm.threads.count",
+          "jvm.cpu.recent_utilization",
+          "jvm.memory.used",
+          "jvm.memory.limit",
+          "jvm.gc.duration",
+          "jvm.class.count",
+          "jvm.thread.count",
           "db.client.connections.usage",
           "db.client.connections.max",
           "db.client.connections.pending_requests",

--- a/custom/src/main/java/com/grafana/extensions/resources/DistributionResource.java
+++ b/custom/src/main/java/com/grafana/extensions/resources/DistributionResource.java
@@ -5,15 +5,17 @@
 
 package com.grafana.extensions.resources;
 
-import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_VERSION;
-
 import com.grafana.extensions.resources.internal.DistributionVersion;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.semconv.ResourceAttributes;
 
 public final class DistributionResource {
+  public static final AttributeKey<String> DISTRIBUTION_NAME =
+      AttributeKey.stringKey("telemetry.distro.name");
+  public static final AttributeKey<String> DISTRIBUTION_VERSION =
+      AttributeKey.stringKey("telemetry.distro.version");
 
   private static final Resource INSTANCE = buildResource();
 
@@ -26,7 +28,10 @@ public final class DistributionResource {
   static Resource buildResource() {
     return Resource.create(
         Attributes.of(
-            TELEMETRY_SDK_NAME, "grafana", TELEMETRY_SDK_VERSION, DistributionVersion.VERSION),
+            DISTRIBUTION_NAME,
+            "grafana-opentelemetry-java",
+            DISTRIBUTION_VERSION,
+            DistributionVersion.VERSION),
         ResourceAttributes.SCHEMA_URL);
   }
 }

--- a/custom/src/main/java/com/grafana/extensions/resources/internal/DistributionVersion.java
+++ b/custom/src/main/java/com/grafana/extensions/resources/internal/DistributionVersion.java
@@ -9,5 +9,5 @@ package com.grafana.extensions.resources.internal;
 
 public class DistributionVersion {
 
-  public static final String VERSION = "0.31.0";
+  public static final String VERSION = "0.32.0-beta.1";
 }

--- a/custom/src/test/java/com/grafana/extensions/resources/DistributionResourceProviderTest.java
+++ b/custom/src/test/java/com/grafana/extensions/resources/DistributionResourceProviderTest.java
@@ -5,8 +5,6 @@
 
 package com.grafana.extensions.resources;
 
-import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.grafana.extensions.resources.internal.DistributionVersion;
@@ -22,8 +20,8 @@ public class DistributionResourceProviderTest {
     Resource r = provider.createResource(null);
     assertThat(r.getAttributes().asMap())
         .hasSize(2)
-        .containsEntry(TELEMETRY_SDK_NAME, "grafana")
-        .containsEntry(TELEMETRY_SDK_VERSION, DistributionVersion.VERSION);
+        .containsEntry(DistributionResource.DISTRIBUTION_NAME, "grafana-opentelemetry-java")
+        .containsEntry(DistributionResource.DISTRIBUTION_VERSION, DistributionVersion.VERSION);
     assertThat(r.getSchemaUrl()).isEqualTo(ResourceAttributes.SCHEMA_URL);
   }
 }

--- a/examples/manual/jvm-dashboard-old.json
+++ b/examples/manual/jvm-dashboard-old.json
@@ -1,0 +1,678 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_GRAFANACLOUD-GREGORZEITLINGER-PROM",
+      "label": "grafanacloud-gregorzeitlinger-prom",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.3.0-63606"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Dashboard for JVM metrics with OpenTelemetry instrumentation",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 18812,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "info",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Semantic Conventions: 1.20.0",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.20.0"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+      },
+      "description": "CPU utilization for the whole system",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "process_runtime_jvm_system_cpu_utilization{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+      },
+      "description": "How much of the available heap memory is used",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 7,
+        "y": 0
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (process_runtime_jvm_memory_usage{job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) (process_runtime_jvm_memory_limit{job=~\"$job\",type=\"heap\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}} - used",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Heap Memory Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+      },
+      "description": "Percentage of time spend for garbage collection pauses",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 7
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(instance) (rate(process_runtime_jvm_gc_duration_sum{job=~\"$job\", instance=~\"$instance\"}[1m]))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Garbage Collection",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+      },
+      "description": "Number of currently loaded classes",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 4,
+        "y": 7
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "process_runtime_jvm_classes_current_loaded{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Classes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+      },
+      "description": "Number of currently executing (also called \"live\") threads",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 9,
+        "y": 7
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+          },
+          "editorMode": "code",
+          "expr": "sum(process_runtime_jvm_threads_count{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Threads",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "JVM",
+    "open-telemetry",
+    "Java",
+    "otel",
+    "opentelemetry",
+    "otlp"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "description": "Choose a Prometheus data source",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+        },
+        "definition": "label_values(process_runtime_jvm_memory_usage,job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(process_runtime_jvm_memory_usage,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_GRAFANACLOUD-GREGORZEITLINGER-PROM}"
+        },
+        "definition": "label_values(process_runtime_jvm_memory_usage{job=~\"$job\"},instance)",
+        "description": "The instance of the application, e.g. pod1",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(process_runtime_jvm_memory_usage{job=~\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "JVM Overview (OpenTelemetry)",
+  "uid": "8Z6ACMK41",
+  "version": 2,
+  "weekStart": ""
+}

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -1,7 +1,7 @@
 {
   "__inputs": [
     {
-      "name": "datasource",
+      "name": "DS_PROMETHEUS",
       "label": "Prometheus",
       "description": "",
       "type": "datasource",
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.1.0-57731pre"
+      "version": "10.0.5"
     },
     {
       "type": "datasource",
@@ -77,7 +77,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "HTTP server request rate",
       "fieldConfig": {
@@ -99,7 +99,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -157,7 +156,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum by (instance) (rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count|http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -173,7 +172,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "HTTP server error ratio - ratio of requests that return 5xx",
       "fieldConfig": {
@@ -195,7 +194,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -253,7 +251,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "(sum by (instance)(rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count\", job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))) or (sum by (instance)(rate({__name__=~\"http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\", http_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))\n",
@@ -269,7 +267,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "HTTP server request duration",
       "fieldConfig": {
@@ -291,7 +289,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -349,7 +346,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "(histogram_quantile(0.95, sum by(le, instance) (rate({__name__=~\"http_server_request_duration_seconds_bucket|http_server_request_duration_bucket|http_server_duration_milliseconds_bucket|http_server_duration_seconds_bucket|http_server_duration_bucket\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))))",
@@ -365,7 +362,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "CPU utilization for the whole system",
       "fieldConfig": {
@@ -387,7 +384,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -445,7 +441,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "{__name__=~\"jvm_cpu_recent_utilization|jvm_cpu_recent_utilization_ratio|process_runtime_jvm_system_cpu_utilization|process_runtime_jvm_system_cpu_utilization_ratio\", job=~\"$job\", instance=~\"$instance\"}",
@@ -460,7 +456,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Used heap memory / heap memory limit ",
       "fieldConfig": {
@@ -482,7 +478,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -540,7 +535,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "(sum by (instance) ({__name__=~\"jvm_memory_used|jvm_memory_used_bytes\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"jvm_memory_limit|jvm_memory_limit_bytes\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"})) or (sum by (instance) ({__name__=~\"process_runtime_jvm_memory_usage|process_runtime_jvm_memory_usage_bytes\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"process_runtime_jvm_memory_limit|process_runtime_jvm_memory_limit_bytes\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}))",
@@ -555,7 +550,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Percentage of time spend for garbage collection pauses",
       "fieldConfig": {
@@ -577,7 +572,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -631,7 +625,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum by(instance) (rate({__name__=~\"jvm_gc_duration_sum|jvm_gc_duration_seconds_sum|process_runtime_jvm_gc_duration_sum|process_runtime_jvm_gc_duration_seconds_sum\",job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
@@ -647,7 +641,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of currently loaded classes",
       "fieldConfig": {
@@ -669,7 +663,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -727,7 +720,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "{__name__=~\"jvm_class_count|process_runtime_jvm_classes_current_loaded\",job=~\"$job\", instance=~\"$instance\"}",
@@ -742,7 +735,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Number of currently executing (also called \"live\") threads",
       "fieldConfig": {
@@ -764,7 +757,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -822,7 +814,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum({__name__=~\"jvm_thread_count|process_runtime_jvm_threads_count\",job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -835,7 +827,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
@@ -851,8 +843,8 @@
       {
         "current": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "description": "Choose a Prometheus data source",
         "hide": 0,
@@ -870,18 +862,10 @@
       },
       {
         "allValue": ".+",
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${datasource}"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values({__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\"},job)",
         "hide": 0,
@@ -905,18 +889,10 @@
       },
       {
         "allValue": ".+",
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${datasource}"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values({__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\", job=~\"$job\"},instance)",
         "description": "The instance of the application, e.g. pod1",
@@ -973,6 +949,6 @@
   "timezone": "",
   "title": "JVM Overview (OpenTelemetry)",
   "uid": "b91844d7-121e-4d0a-93b8-a9c1a05703b3",
-  "version": 4,
+  "version": 1,
   "weekStart": ""
 }

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -160,7 +160,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-            "expr": "sum by (instance) (rate({__name__=~\"http_server_(request_)?duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+            "expr": "sum by (instance) (rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count|http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -256,7 +256,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum by (instance)(rate({__name__=~\"http_server_request_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_request_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))) or (sum by (instance)(rate({__name__=~\"http_server_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\", http_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))\n",
+          "expr": "(sum by (instance)(rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count\", job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))) or (sum by (instance)(rate({__name__=~\"http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\", http_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))\n",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -352,7 +352,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(histogram_quantile(0.95, sum by(le, instance) (rate({__name__=~\"http_server_(request_)?duration_(milli)?(seconds_)?bucket\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))))",
+          "expr": "(histogram_quantile(0.95, sum by(le, instance) (rate({__name__=~\"http_server_request_duration_seconds_bucket|http_server_request_duration_bucket|http_server_duration_milliseconds_bucket|http_server_duration_seconds_bucket|http_server_duration_bucket\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))))",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -448,7 +448,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "{__name__=~\"(jvm_cpu_recent_utilization(_ratio)?|process_runtime_jvm_system_cpu_utilization(_ratio)?)\", job=~\"$job\", instance=~\"$instance\"}",
+          "expr": "{__name__=~\"jvm_cpu_recent_utilization|jvm_cpu_recent_utilization_ratio|process_runtime_jvm_system_cpu_utilization|process_runtime_jvm_system_cpu_utilization_ratio\", job=~\"$job\", instance=~\"$instance\"}",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -543,7 +543,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum by (instance) ({__name__=~\"jvm_memory_used(_bytes)?\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"jvm_memory_limit(_bytes)?\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"})) or (sum by (instance) ({__name__=~\"process_runtime_jvm_memory_usage(_bytes)?\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"process_runtime_jvm_memory_limit(_bytes)?\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}))",
+          "expr": "(sum by (instance) ({__name__=~\"jvm_memory_used|jvm_memory_used_bytes\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"jvm_memory_limit|jvm_memory_limit_bytes\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"})) or (sum by (instance) ({__name__=~\"process_runtime_jvm_memory_usage|process_runtime_jvm_memory_usage_bytes\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"process_runtime_jvm_memory_limit|process_runtime_jvm_memory_limit_bytes\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}))",
           "legendFormat": "{{instance}} - used",
           "range": true,
           "refId": "A"
@@ -634,7 +634,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(instance) (rate({__name__=~\"(process_runtime_)?jvm_gc_duration_(seconds_)?sum\",job=~\"$job\", instance=~\"$instance\"}[1m]))",
+          "expr": "sum by(instance) (rate({__name__=~\"jvm_gc_duration_sum|jvm_gc_duration_seconds_sum|process_runtime_jvm_gc_duration_sum|process_runtime_jvm_gc_duration_seconds_sum\",job=~\"$job\", instance=~\"$instance\"}[1m]))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -159,8 +159,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "jvm_cpu_recent_utilization{job=~\"$job\", instance=~\"$instance\"} or process_runtime_jvm_system_cpu_utilization{job=~\"$job\", instance=~\"$instance\"}",
-          "legendFormat": "{{instance}}",
+          "expr": "{__name__=~\"(jvm_cpu_recent_utilization(_ratio)?|process_runtime_jvm_system_cpu_utilization(_ratio)?)\", job=~\"$job\", instance=~\"$instance\"}",
           "range": true,
           "refId": "A"
         }
@@ -253,7 +252,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(sum by (instance) (jvm_memory_used{job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) (jvm_memory_limit{job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"})) or (sum by (instance) (process_runtime_jvm_memory_usage{job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) (process_runtime_jvm_memory_limit{job=~\"$job\",type=\"heap\", instance=~\"$instance\"}))",
+          "expr": "(sum by (instance) ({__name__=~\"jvm_memory_used(_bytes)?\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"jvm_memory_limit(_bytes)?\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"})) or (sum by (instance) ({__name__=~\"process_runtime_jvm_memory_usage(_bytes)?\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"process_runtime_jvm_memory_limit(_bytes)?\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}))",
           "legendFormat": "{{instance}} - used",
           "range": true,
           "refId": "A"
@@ -343,7 +342,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(instance) (rate(jvm_gc_duration_sum{job=~\"$job\", instance=~\"$instance\"}[1m])) or sum by(instance) (rate(process_runtime_jvm_gc_duration_sum{job=~\"$job\", instance=~\"$instance\"}[1m]))",
+          "expr": "sum by(instance) (rate({__name__=~\"(process_runtime_)?jvm_gc_duration_(seconds_)?sum\",job=~\"$job\", instance=~\"$instance\"}[1m]))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -438,7 +437,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "jvm_class_count{job=~\"$job\", instance=~\"$instance\"} or process_runtime_jvm_classes_current_loaded{job=~\"$job\", instance=~\"$instance\"}",
+          "expr": "{__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\",job=~\"$job\", instance=~\"$instance\"}",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -532,7 +531,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(jvm_thread_count{job=~\"$job\", instance=~\"$instance\"}) by (instance) or sum(process_runtime_jvm_threads_count{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "expr": "sum({__name__=~\"(jvm_thread_count|process_runtime_jvm_threads_count)\",job=~\"$job\", instance=~\"$instance\"}) by (instance)",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -1,4 +1,35 @@
 {
+  "__inputs": [
+    {
+      "name": "datasource",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.1.0-57731pre"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -26,7 +57,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 18812,
   "graphTooltip": 0,
-  "id": 1,
+  "id": null,
   "links": [
     {
       "asDropdown": false,
@@ -35,8 +66,8 @@
       "keepTime": false,
       "tags": [],
       "targetBlank": false,
-      "title": "Semantic Conventions: 1.20.0",
-      "tooltip": "",
+      "title": "Semantic Conventions: 1.20.0 - 1.22.0",
+      "tooltip": "multiple versions of the semantic conventions are supported using 'or' and regex queries",
       "type": "link",
       "url": "https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.20.0"
     }
@@ -68,6 +99,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -163,6 +195,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -258,6 +291,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -353,6 +387,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -447,6 +482,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -541,6 +577,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -597,7 +634,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(instance) (rate({__name__=~\"jvm_gc_duration_sum|jvm_gc_duration_seconds_sum|process_runtime_jvm_gc_duration_sum|process_runtime_jvm_gc_duration_seconds_sum\",job=~\"$job\", instance=~\"$instance\"}[1m]))",
+          "expr": "sum by(instance) (rate({__name__=~\"jvm_gc_duration_sum|jvm_gc_duration_seconds_sum|process_runtime_jvm_gc_duration_sum|process_runtime_jvm_gc_duration_seconds_sum\",job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -632,6 +669,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -726,6 +764,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -796,7 +835,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": false,
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
@@ -812,8 +851,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "default",
+          "value": "default"
         },
         "description": "Choose a Prometheus data source",
         "hide": 0,
@@ -934,6 +973,6 @@
   "timezone": "",
   "title": "JVM Overview (OpenTelemetry)",
   "uid": "b91844d7-121e-4d0a-93b8-a9c1a05703b3",
-  "version": 1,
+  "version": 4,
   "weekStart": ""
 }

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -1,35 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "datasource",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "10.1.0-57731pre"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -57,7 +26,7 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 18812,
   "graphTooltip": 0,
-  "id": null,
+  "id": 1,
   "links": [
     {
       "asDropdown": false,
@@ -99,7 +68,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -160,7 +128,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-            "expr": "sum by (instance) (rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count|http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum by (instance) (rate({__name__=~\"http_server_request_duration_seconds_count|http_server_request_duration_count|http_server_duration_milliseconds_count|http_server_duration_seconds_count|http_server_duration_count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -195,7 +163,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -291,7 +258,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -387,7 +353,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -482,7 +447,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -577,7 +541,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -669,7 +632,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -764,7 +726,6 @@
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -835,7 +796,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
@@ -851,8 +812,8 @@
       {
         "current": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "description": "Choose a Prometheus data source",
         "hide": 0,
@@ -870,12 +831,20 @@
       },
       {
         "allValue": ".+",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(process_runtime_jvm_memory_usage,job)",
+        "definition": "label_values({__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\"},job)",
         "hide": 0,
         "includeAll": true,
         "label": "Job",
@@ -883,7 +852,7 @@
         "name": "job",
         "options": [],
         "query": {
-          "query": "label_values(process_runtime_jvm_memory_usage,job)",
+          "query": "label_values({__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\"},job)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -897,12 +866,20 @@
       },
       {
         "allValue": ".+",
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(process_runtime_jvm_memory_usage{job=~\"$job\"},instance)",
+        "definition": "label_values({__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\", job=~\"$job\"},instance)",
         "description": "The instance of the application, e.g. pod1",
         "hide": 0,
         "includeAll": true,
@@ -911,7 +888,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(process_runtime_jvm_memory_usage{job=~\"$job\"},instance)",
+          "query": "label_values({__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\", job=~\"$job\"},instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -957,6 +934,6 @@
   "timezone": "",
   "title": "JVM Overview (OpenTelemetry)",
   "uid": "b91844d7-121e-4d0a-93b8-a9c1a05703b3",
-  "version": 13,
+  "version": 1,
   "weekStart": ""
 }

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -1,0 +1,669 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.5"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Dashboard for JVM metrics with OpenTelemetry instrumentation",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 18812,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "info",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Semantic Conventions: 1.20.0",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://github.com/open-telemetry/semantic-conventions/blob/main/schemas/1.20.0"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "CPU utilization for the whole system",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "jvm_cpu_recent_utilization{job=~\"$job\", instance=~\"$instance\"} or process_runtime_jvm_system_cpu_utilization{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "How much of the available heap memory is used",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 7,
+        "y": 0
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by (instance) (jvm_memory_used{job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) (jvm_memory_limit{job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"})) or (sum by (instance) (process_runtime_jvm_memory_usage{job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) (process_runtime_jvm_memory_limit{job=~\"$job\",type=\"heap\", instance=~\"$instance\"}))",
+          "legendFormat": "{{instance}} - used",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Heap Memory Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Percentage of time spend for garbage collection pauses",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 7
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(instance) (rate(jvm_gc_duration_sum{job=~\"$job\", instance=~\"$instance\"}[1m])) or sum by(instance) (rate(process_runtime_jvm_gc_duration_sum{job=~\"$job\", instance=~\"$instance\"}[1m]))",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Garbage Collection",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of currently loaded classes",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 4,
+        "y": 7
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "jvm_class_count{job=~\"$job\", instance=~\"$instance\"} or process_runtime_jvm_classes_current_loaded{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Classes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of currently executing (also called \"live\") threads",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 9,
+        "y": 7
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(jvm_thread_count{job=~\"$job\", instance=~\"$instance\"}) by (instance) or sum(process_runtime_jvm_threads_count{job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Threads",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "JVM",
+    "open-telemetry",
+    "Java",
+    "otel",
+    "opentelemetry",
+    "otlp"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "Choose a Prometheus data source",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(process_runtime_jvm_memory_usage,job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(process_runtime_jvm_memory_usage,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(process_runtime_jvm_memory_usage{job=~\"$job\"},instance)",
+        "description": "The instance of the application, e.g. pod1",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(process_runtime_jvm_memory_usage{job=~\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "JVM Overview (OpenTelemetry)",
+  "uid": "8Z6ACMK41",
+  "version": 1,
+  "weekStart": ""
+}

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -1,7 +1,7 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
+      "name": "datasource",
       "label": "Prometheus",
       "description": "",
       "type": "datasource",
@@ -15,7 +15,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "10.0.5"
+      "version": "10.1.0-57731pre"
     },
     {
       "type": "datasource",
@@ -77,7 +77,295 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
+      },
+      "description": "HTTP server request rate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+            "expr": "sum by (instance) (rate({__name__=~\"http_server_(request_)?duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HTTP server error ratio - ratio of requests that return 5xx",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 4,
+        "y": 0
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum by (instance)(rate({__name__=~\"http_server_request_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_request_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))) or (sum by (instance)(rate({__name__=~\"http_server_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\", http_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate({__name__=~\"http_server_duration_(milli)?(seconds_)?count\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))\n",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HTTP server request duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 9,
+        "y": 0
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.95, sum by(le, instance) (rate({__name__=~\"http_server_(request_)?duration_(milli)?(seconds_)?bucket\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))))",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
       "description": "CPU utilization for the whole system",
       "fieldConfig": {
@@ -92,13 +380,14 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 30,
+            "fillOpacity": 25,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -137,7 +426,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 38,
       "options": {
@@ -156,10 +445,11 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "{__name__=~\"(jvm_cpu_recent_utilization(_ratio)?|process_runtime_jvm_system_cpu_utilization(_ratio)?)\", job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -170,9 +460,9 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
-      "description": "How much of the available heap memory is used",
+      "description": "Used heap memory / heap memory limit ",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -192,6 +482,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -230,7 +521,7 @@
         "h": 7,
         "w": 7,
         "x": 7,
-        "y": 0
+        "y": 8
       },
       "id": 30,
       "options": {
@@ -249,7 +540,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "(sum by (instance) ({__name__=~\"jvm_memory_used(_bytes)?\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"jvm_memory_limit(_bytes)?\",job=~\"$job\",jvm_memory_type=\"heap\", instance=~\"$instance\"})) or (sum by (instance) ({__name__=~\"process_runtime_jvm_memory_usage(_bytes)?\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}) / on(instance) sum by (instance) ({__name__=~\"process_runtime_jvm_memory_limit(_bytes)?\",job=~\"$job\",type=\"heap\", instance=~\"$instance\"}))",
@@ -264,7 +555,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "description": "Percentage of time spend for garbage collection pauses",
       "fieldConfig": {
@@ -279,13 +570,14 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 30,
+            "fillOpacity": 25,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -320,7 +612,7 @@
         "h": 7,
         "w": 4,
         "x": 0,
-        "y": 7
+        "y": 15
       },
       "id": 46,
       "options": {
@@ -339,7 +631,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum by(instance) (rate({__name__=~\"(process_runtime_)?jvm_gc_duration_(seconds_)?sum\",job=~\"$job\", instance=~\"$instance\"}[1m]))",
@@ -355,7 +647,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "description": "Number of currently loaded classes",
       "fieldConfig": {
@@ -377,6 +669,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -415,7 +708,7 @@
         "h": 7,
         "w": 5,
         "x": 4,
-        "y": 7
+        "y": 15
       },
       "id": 33,
       "options": {
@@ -434,7 +727,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "{__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\",job=~\"$job\", instance=~\"$instance\"}",
@@ -449,7 +742,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "description": "Number of currently executing (also called \"live\") threads",
       "fieldConfig": {
@@ -464,13 +757,14 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 30,
+            "fillOpacity": 25,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -509,7 +803,7 @@
         "h": 7,
         "w": 5,
         "x": 9,
-        "y": 7
+        "y": 15
       },
       "id": 42,
       "options": {
@@ -528,7 +822,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum({__name__=~\"(jvm_thread_count|process_runtime_jvm_threads_count)\",job=~\"$job\", instance=~\"$instance\"}) by (instance)",
@@ -541,7 +835,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": false,
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
@@ -557,8 +851,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
+          "text": "default",
+          "value": "default"
         },
         "description": "Choose a Prometheus data source",
         "hide": 0,
@@ -579,7 +873,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "definition": "label_values(process_runtime_jvm_memory_usage,job)",
         "hide": 0,
@@ -606,7 +900,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "definition": "label_values(process_runtime_jvm_memory_usage{job=~\"$job\"},instance)",
         "description": "The instance of the application, e.g. pod1",
@@ -662,7 +956,7 @@
   },
   "timezone": "",
   "title": "JVM Overview (OpenTelemetry)",
-  "uid": "8Z6ACMK41",
-  "version": 1,
+  "uid": "b91844d7-121e-4d0a-93b8-a9c1a05703b3",
+  "version": 13,
   "weekStart": ""
 }

--- a/examples/manual/jvm-dashboard.json
+++ b/examples/manual/jvm-dashboard.json
@@ -730,7 +730,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "{__name__=~\"(jvm_class_count|process_runtime_jvm_classes_current_loaded)\",job=~\"$job\", instance=~\"$instance\"}",
+          "expr": "{__name__=~\"jvm_class_count|process_runtime_jvm_classes_current_loaded\",job=~\"$job\", instance=~\"$instance\"}",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -825,7 +825,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum({__name__=~\"(jvm_thread_count|process_runtime_jvm_threads_count)\",job=~\"$job\", instance=~\"$instance\"}) by (instance)",
+          "expr": "sum({__name__=~\"jvm_thread_count|process_runtime_jvm_threads_count\",job=~\"$job\", instance=~\"$instance\"}) by (instance)",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"

--- a/examples/manual/oats-template.yaml
+++ b/examples/manual/oats-template.yaml
@@ -10,3 +10,16 @@ expected:
   metrics:
     - promql: 'cart_client{}' # created programmatically
       value: '>= 0'
+  dashboards:
+    - path: ../jvm-dashboard.json
+      panels:
+        - title: CPU utilization
+          value: "> 0"
+        - title: Heap Memory Utilization
+          value: "> 0"
+        - title: Garbage Collection
+          value: ">= 0"
+        - title: Classes
+          value: "> 0"
+        - title: Threads
+          value: "> 0"

--- a/examples/manual/oats-template.yaml
+++ b/examples/manual/oats-template.yaml
@@ -1,5 +1,26 @@
-docker-compose:
-  generator: java
+matrix:
+  - name: new
+    docker-compose:
+      generator: java
+  - name: old-jvm-metrics
+    docker-compose:
+      generator: java
+      java-generator-params:
+        old-jvm-metrics: true
+        disable-data-saver: true
+  - name: prom-naming
+    docker-compose:
+      generator: java
+      java-generator-params:
+        disable-data-saver: true
+        prom-naming: true
+  - name: prom-naming-old-jvm-metrics
+    docker-compose:
+      generator: java
+      java-generator-params:
+        disable-data-saver: true
+        old-jvm-metrics: true
+        prom-naming: true
 input:
   - path: /stock
 expected:
@@ -14,7 +35,7 @@ expected:
     - path: ../jvm-dashboard.json
       panels:
         - title: CPU utilization
-          value: "> 0"
+          value: ">= 0"
         - title: Heap Memory Utilization
           value: "> 0"
         - title: Garbage Collection

--- a/examples/manual/oats-template.yaml
+++ b/examples/manual/oats-template.yaml
@@ -1,20 +1,25 @@
 matrix:
-  - name: new
+  - name: data-saver
     docker-compose:
       generator: java
-  - name: old-jvm-metrics
+  - name: no-data-saver-new
+    docker-compose:
+      generator: java
+      java-generator-params:
+        disable-data-saver: true # RED metrics are not included in data saver
+  - name: no-data-saver-old-jvm-metrics
     docker-compose:
       generator: java
       java-generator-params:
         old-jvm-metrics: true
         disable-data-saver: true
-  - name: prom-naming
+  - name: no-data-saver-prom-naming
     docker-compose:
       generator: java
       java-generator-params:
         disable-data-saver: true
         prom-naming: true
-  - name: prom-naming-old-jvm-metrics
+  - name: no-data-saver-prom-naming-old-jvm-metrics
     docker-compose:
       generator: java
       java-generator-params:
@@ -31,9 +36,22 @@ expected:
   metrics:
     - promql: 'cart_client{}' # created programmatically
       value: '>= 0'
+      matrix-condition: "^data-saver$"
+    - promql: 'cart_client_total{}' # created programmatically
+      value: '>= 0'
+      matrix-condition: ".*prom-naming.*"
   dashboards:
     - path: ../jvm-dashboard.json
       panels:
+        - title: Rate
+          value: "> 0"
+          matrix-condition: "no-data-saver-.*"
+        - title: Error %
+          value: "> 0"
+          matrix-condition: "no-data-saver-.*"
+        - title: Duration
+          value: "> 0"
+          matrix-condition: "no-data-saver-.*"
         - title: CPU utilization
           value: ">= 0"
         - title: Heap Memory Utilization

--- a/examples/manual/oats-template.yaml
+++ b/examples/manual/oats-template.yaml
@@ -1,25 +1,25 @@
 matrix:
-  - name: data-saver
+  - name: data-saver-on--prom-naming-off--new-jvm-metrics
     docker-compose:
       generator: java
-  - name: no-data-saver-new
+  - name: data-saver-off--prom-naming-off--new-jvm-metrics
     docker-compose:
       generator: java
       java-generator-params:
-        disable-data-saver: true # RED metrics are not included in data saver
-  - name: no-data-saver-old-jvm-metrics
+        disable-data-saver: true
+  - name: data-saver-off--prom-naming-off--old-jvm-metrics
     docker-compose:
       generator: java
       java-generator-params:
         old-jvm-metrics: true
         disable-data-saver: true
-  - name: no-data-saver-prom-naming
+  - name: data-saver-off--prom-naming-on--new-jvm-metrics
     docker-compose:
       generator: java
       java-generator-params:
         disable-data-saver: true
         prom-naming: true
-  - name: no-data-saver-prom-naming-old-jvm-metrics
+  - name: data-saver-off--prom-naming-on--old-jvm-metrics
     docker-compose:
       generator: java
       java-generator-params:
@@ -36,22 +36,22 @@ expected:
   metrics:
     - promql: 'cart_client{}' # created programmatically
       value: '>= 0'
-      matrix-condition: "^data-saver$"
+      matrix-condition: "prom-naming-off"
     - promql: 'cart_client_total{}' # created programmatically
       value: '>= 0'
-      matrix-condition: ".*prom-naming.*"
+      matrix-condition: "prom-naming-on"
   dashboards:
     - path: ../jvm-dashboard.json
       panels:
         - title: Rate
           value: "> 0"
-          matrix-condition: "no-data-saver-.*"
+          matrix-condition: "data-saver-off"
         - title: Error %
           value: "> 0"
-          matrix-condition: "no-data-saver-.*"
+          matrix-condition: "data-saver-off"
         - title: Duration
           value: "> 0"
-          matrix-condition: "no-data-saver-.*"
+          matrix-condition: "data-saver-off"
         - title: CPU utilization
           value: ">= 0"
         - title: Heap Memory Utilization

--- a/examples/manual/spring-boot-non-reactive-2.7/build.gradle
+++ b/examples/manual/spring-boot-non-reactive-2.7/build.gradle
@@ -15,8 +15,8 @@ repositories {
 
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-web'
-  implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.31.0')
-  implementation('io.opentelemetry:opentelemetry-api:1.31.0')
+  implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.32.0')
+  implementation('io.opentelemetry:opentelemetry-api:1.32.0')
 }
 
 bootRun {

--- a/examples/manual/spring-boot-non-reactive-2.7/src/main/java/com/grafana/demo/CartClient.java
+++ b/examples/manual/spring-boot-non-reactive-2.7/src/main/java/com/grafana/demo/CartClient.java
@@ -8,10 +8,13 @@ package com.grafana.demo;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.Random;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CartClient {
+
+  private final Random random = new Random();
 
   private final LongCounter counter =
       GlobalOpenTelemetry.get().getMeter("application").counterBuilder("cart_client").build();
@@ -19,6 +22,9 @@ public class CartClient {
   @WithSpan("get_cart")
   public String getCart() {
     counter.add(1);
+    if (random.nextBoolean()) {
+      throw new RuntimeException("Failed to get cart");
+    }
     return "cart";
   }
 }

--- a/examples/manual/spring-boot-non-reactive-3.1/build.gradle
+++ b/examples/manual/spring-boot-non-reactive-3.1/build.gradle
@@ -17,8 +17,8 @@ repositories {
 
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-web'
-  implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.31.0')
-  implementation('io.opentelemetry:opentelemetry-api:1.31.0')
+  implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.32.0')
+  implementation('io.opentelemetry:opentelemetry-api:1.32.0')
 }
 
 bootRun {

--- a/examples/manual/spring-boot-non-reactive-3.1/src/main/java/com/grafana/demo/CartClient.java
+++ b/examples/manual/spring-boot-non-reactive-3.1/src/main/java/com/grafana/demo/CartClient.java
@@ -8,10 +8,13 @@ package com.grafana.demo;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.Random;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CartClient {
+
+  private final Random random = new Random();
 
   private final LongCounter counter =
       GlobalOpenTelemetry.get().getMeter("application").counterBuilder("cart_client").build();
@@ -19,6 +22,9 @@ public class CartClient {
   @WithSpan("get_cart")
   public String getCart() {
     counter.add(1);
+    if (random.nextBoolean()) {
+      throw new RuntimeException("Failed to get cart");
+    }
     return "cart";
   }
 }

--- a/examples/run-example.sh
+++ b/examples/run-example.sh
@@ -33,7 +33,7 @@ done
 
 "$scriptDir"/start-grafana-agent.sh
 
-agentVersion=0.31.0
+agentVersion=0.32.0-beta.1
 agent="grafana-opentelemetry-java-$agentVersion.jar"
 agentPath="$scriptDir/$agent"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,9 +6,8 @@ if [ -z "$newVersion" ]; then
   exit 1
 fi
 
-res="${newVersion//[^.]}"
-if [ "${#res}" -ne 2 ]; then
-  echo "new version $newVersion is not valid - new version should be in the format of x.y.z"
+if [[ ! "$newVersion" =~ ^0\.[0-9]{2}\.[0-9]+-beta\.[0-9]+$ ]]; then
+  echo "new version $newVersion is not valid - new version should be in the format of x.y.z-beta.w"
   exit 1
 fi
 

--- a/smoke-tests/src/test/java/com/grafana/extensions/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/grafana/extensions/smoketest/SpringBootSmokeTest.java
@@ -8,7 +8,6 @@ package com.grafana.extensions.smoketest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.grafana.extensions.filter.DefaultMetrics;
-import com.grafana.extensions.resources.DistributionResource;
 import com.grafana.extensions.resources.internal.DistributionVersion;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.io.IOException;
@@ -40,16 +39,9 @@ class SpringBootSmokeTest extends SmokeTest {
     assertThat(countSpansByName(traces, "WebController.greeting")).isEqualTo(1);
     assertThat(countSpansByName(traces, "WebController.withSpan")).isEqualTo(1);
     assertThat(
-            countResourcesByValue(
-                traces,
-                DistributionResource.DISTRIBUTION_VERSION.getKey(),
-                DistributionVersion.VERSION))
+            countResourcesByValue(traces, "telemetry.distro.version", DistributionVersion.VERSION))
         .isGreaterThan(0);
-    assertThat(
-            countResourcesByValue(
-                traces,
-                DistributionResource.DISTRIBUTION_NAME.getKey(),
-                "grafana-opentelemetry-java"))
+    assertThat(countResourcesByValue(traces, "telemetry.distro.name", "grafana-opentelemetry-java"))
         .isGreaterThan(0);
 
     assertThat(getLogMessages(waitForLogs())).contains("HTTP request received");

--- a/smoke-tests/src/test/java/com/grafana/extensions/smoketest/SpringBootSmokeTest.java
+++ b/smoke-tests/src/test/java/com/grafana/extensions/smoketest/SpringBootSmokeTest.java
@@ -5,11 +5,10 @@
 
 package com.grafana.extensions.smoketest;
 
-import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.TELEMETRY_SDK_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.grafana.extensions.filter.DefaultMetrics;
+import com.grafana.extensions.resources.DistributionResource;
 import com.grafana.extensions.resources.internal.DistributionVersion;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import java.io.IOException;
@@ -42,13 +41,19 @@ class SpringBootSmokeTest extends SmokeTest {
     assertThat(countSpansByName(traces, "WebController.withSpan")).isEqualTo(1);
     assertThat(
             countResourcesByValue(
-                traces, TELEMETRY_SDK_VERSION.getKey(), DistributionVersion.VERSION))
+                traces,
+                DistributionResource.DISTRIBUTION_VERSION.getKey(),
+                DistributionVersion.VERSION))
         .isGreaterThan(0);
-    assertThat(countResourcesByValue(traces, TELEMETRY_SDK_NAME.getKey(), "grafana"))
+    assertThat(
+            countResourcesByValue(
+                traces,
+                DistributionResource.DISTRIBUTION_NAME.getKey(),
+                "grafana-opentelemetry-java"))
         .isGreaterThan(0);
 
     assertThat(getLogMessages(waitForLogs())).contains("HTTP request received");
-    assertThat(getMetricNames(waitForMetrics())).contains("process.runtime.jvm.buffer.limit");
+    assertThat(getMetricNames(waitForMetrics())).contains("jvm.memory.committed");
   }
 
   private String makeGreetCall() {
@@ -65,7 +70,7 @@ class SpringBootSmokeTest extends SmokeTest {
     makeGreetCall();
 
     List<String> metricNames = getMetricNames(waitForMetrics());
-    assertThat(metricNames).contains("process.runtime.jvm.memory.usage");
+    assertThat(metricNames).contains("jvm.memory.used");
     // all other metrics should have been filtered out
     assertThat(DefaultMetrics.DEFAULT_METRICS)
         .containsOnlyOnceElementsOf(new HashSet<>(metricNames));


### PR DESCRIPTION
blocked on discussion about breaking changes of jvm semantic conventions 
  - this is unblocked now, we have decided that multiple versions of semantic conventions should be supported on the query side and this can be done as shown here: https://github.com/grafana/docker-otel-lgtm/blob/8551b33c2da413ce2c55350fd4d9de9f929f9b88/docker/grafana-dashboard-jvm-metrics.json#L708

- Update to OpenTelemetry 1.32.0
- **Breaking Change**: Use new [JVM semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/)
- **Breaking Change**: Use `telemetry.distro.name` = `grafana-opentelemetry-java` 
  and `telemetry.distro.version` = `0.32.0-beta.1` to identify this distribution instead of 
  `telemetry.sdk.name` = `grafana-opentelemetry-java` and `telemetry.sdk.version` = `0.32.0`
  (for reference: from now on `telemetry.sdk.name` = `opentelemetry` and `telemetry.sdk.version` = `1.32.0`.
- update the jvm dashboard to support multiple setups
  - this jvm dashboard can be used for older and the upcoming versions of this distribution to mitigate the breaking change
  - application observability will also use this dashboard
  - the [community dashboard](https://grafana.com/grafana/dashboards/18812-jvm-overview-opentelemetry/) will also be updated to use this logic
  - supported variants
    - prometheus naming conventions or not
    - new jvm semantic conventions or not
  - based on [oats PR](https://github.com/grafana/oats/pull/36)
