### PR TITLE
fix: don't send span when windows is not full

### DIFF
--- a/custom/src/test/java/com/grafana/extensions/servertiming/ServerTimingHeaderReaderTest.java
+++ b/custom/src/test/java/com/grafana/extensions/servertiming/ServerTimingHeaderReaderTest.java
@@ -50,7 +50,6 @@ class ServerTimingHeaderReaderTest {
           String serverTiming = ServerTimingHeaderCustomizer.toHeaderValue(Context.current());
           serverTimingHeaderReader.consume(
               new StringHttpCommonAttributesGetter(serverTiming), "request", "response");
-          System.out.println(serverTiming);
           assertThat(DynamicSampler.getInstance().getSampledTraces()).doesNotContain(traceId);
         });
   }


### PR DESCRIPTION
Fixes #

##  Changes

 Don't send span when window is not full

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-java) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
