### PR TITLE
check if the agentArgs are null during bootstrap

### DIFF
--- a/bootstrap/src/main/java/com/grafana/AgentStarted.java
+++ b/bootstrap/src/main/java/com/grafana/AgentStarted.java
@@ -9,7 +9,7 @@ public class AgentStarted {
   @SuppressWarnings("SystemOut")
   public static void run(String agentArgs) {
     boolean debug = false;
-    if (!agentArgs.isEmpty()) {
+    if (agentArgs != null && !agentArgs.isEmpty()) {
       String[] options = agentArgs.split(",");
       for (String option : options) {
         String[] keyValue = option.split("=");


### PR DESCRIPTION
Fixes #

PR #910 broke the ability to use the standard Java agnet OPTS:
JAVA_OPTS="-javaagent:grafana-opentelemetry-java.jar"

it requires us now to use:
JAVA_OPTS="-javaagent:grafana-opentelemetry-java.jar="

Notice the equal symbol at the end. The agentArgs are null if the equal symbol is not entered. Causing the isEmpty check to fail.

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(Unknown Source)
	at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(Unknown Source)
Caused by: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "agentArgs" is null
	at com.grafana.AgentStarted.run(AgentStarted.java:12)
	at com.grafana.GrafanaOpenTelemetryAgent.startAgent(GrafanaOpenTelemetryAgent.java:53)
	at com.grafana.GrafanaOpenTelemetryAgent.premain(GrafanaOpenTelemetryAgent.java:45)
	... 4 more
*** java.lang.instrument ASSERTION FAILED ***: "result" with message agent load/premain call failed at src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 422
FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed
```

## Changes

Check if agentArgs is not null AND the string is not empty.

## Merge requirement checklist

* [ ] Unit tests added/updated
* [ ] [`CHANGELOG.md`](https://github.com/grafana/grafana-opentelemetry-java) file updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
