### PR TITLE
Enable dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   branchPrefix: "grafanarenovatebot/",
   platformCommit: "enabled",
   automerge: true,
-  dependencyDashboard: false,
+  dependencyDashboard: true,
   forkProcessing: "enabled",
   rebaseWhen: "behind-base-branch",
   labels: ["dependencies"],


### PR DESCRIPTION
Re-enable the renovate dependency dashboard to use with Grafana's managed renovate instance.
