### PR TITLE
Migrate from push-to-gar-docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,15 @@ jobs:
             LICENSE
 
       - name: Push to Docker (for OpenTelemetry Operator)
-        uses: grafana/shared-workflows/actions/push-to-gar-docker@dc66ed7a5dc1f49848b06068ae024e96e26d4761 # push-to-gar-docker/v0.5.2
+        uses: grafana/shared-workflows/actions/docker-build-push-image@b3d136565946d8788dd6812881fb0fb2fe14bacb # docker-build-push-image/v0.2.0
         with:
-          registry: "us-docker.pkg.dev"
-          image_name: grafana-opentelemetry-java
           context: .
+          gar-environment: "prod"
+          gar-image: grafana-opentelemetry-java
+          gar-registry: "us-docker.pkg.dev"
           file: scripts/otel_operator/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          registries: gar
           tags: |
             type=match,pattern=v(.*),group=1
             latest
-          environment: "prod"
-          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Migrate from `push-to-gar-docker` to `docker-build-push-image` as the [GAR action is now deprecated](https://github.com/grafana/shared-workflows/tree/main/actions/push-to-gar-docker#push-to-gar-docker).

[Migration guide](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating-from-push-to-gar-docker) used to add/update settings.

Spotted after I noticed the warning `Unexpected input(s) 'environment', 'delete_credentials_file', valid inputs are ['registry', 'workspace_credentials']` in [the build for the v2.23.1 release](https://github.com/grafana/grafana-opentelemetry-java/actions/runs/20917087754).