### PR TITLE
Attest JAR file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       actions: read
+      attestations: write
       contents: write
       id-token: write
 
@@ -35,6 +36,12 @@ jobs:
         run: mise run build-release
         env:
           TAG: ${{ github.ref_name }}
+
+      - name: Attest artifacts
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: |
+            agent/build/libs/grafana-opentelemetry-java.jar
 
       - name: Get release actor user type
         id: get-release-actor-user-type


### PR DESCRIPTION
Attest the build provenance of the JAR file built as part of releases.
