### PR TITLE
Add declarative configuration support

### DIFF
--- a/custom/build.gradle
+++ b/custom/build.gradle
@@ -1,46 +1,48 @@
 plugins {
-  id "java"
-  id "org.owasp.dependencycheck" version "12.2.0"
+    id "java"
+    id "org.owasp.dependencycheck" version "12.2.0"
 }
 
 apply from: "$rootDir/gradle/checkstyle.gradle"
 
 dependencies {
-  compileOnly("io.opentelemetry:opentelemetry-sdk")
-  compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
-  compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
-  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
-  compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
+    compileOnly("io.opentelemetry:opentelemetry-sdk")
+    compileOnly("io.opentelemetry.semconv:opentelemetry-semconv")
+    compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+    compileOnly("io.opentelemetry:opentelemetry-sdk-extension-incubator")
+    compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
+    compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-tooling")
 
-  testImplementation("io.opentelemetry.semconv:opentelemetry-semconv")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
-  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
-  testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
+    testImplementation("io.opentelemetry.semconv:opentelemetry-semconv")
+    testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
+    testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
+    testImplementation("io.opentelemetry.javaagent:opentelemetry-testing-common")
+    testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api")
+    testImplementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
 }
 
 dependencyCheck {
-  skipConfigurations = ["checkstyle", "annotationProcessor"]
-  suppressionFile = "buildscripts/dependency-check-suppressions.xml"
-  failBuildOnCVSS = 7.0f // fail on high or critical CVE
+    skipConfigurations = ["checkstyle", "annotationProcessor"]
+    suppressionFile = "buildscripts/dependency-check-suppressions.xml"
+    failBuildOnCVSS = 7.0f // fail on high or critical CVE
 }
 
 def updateGeneratedFile(file, newContent) {
-  if (System.getenv("CHECK_GENERATED_FILES") == "true") {
-    def oldContent = file.text
-    if (oldContent != newContent) {
-      throw new GradleException("File ${file} was modified in CI. Please update it locally and commit.")
+    if (System.getenv("CHECK_GENERATED_FILES") == "true") {
+        def oldContent = file.text
+        if (oldContent != newContent) {
+            throw new GradleException("File ${file} was modified in CI. Please update it locally and commit.")
+        }
+    } else {
+        project.mkdir(file.parent)
+        file.text = newContent
     }
-  } else {
-    project.mkdir(file.parent)
-    file.text = newContent
-  }
 }
 
 tasks.register('manageVersionClass') {
-  doLast {
-    updateGeneratedFile(new File("${projectDir}/src/main/java/com/grafana/extensions/resources/internal", "DistributionVersion.java"),
-      """/*
+    doLast {
+        updateGeneratedFile(new File("${projectDir}/src/main/java/com/grafana/extensions/resources/internal", "DistributionVersion.java"),
+                """/*
  * Copyright Grafana Labs
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -54,7 +56,7 @@ public class DistributionVersion {
   public static final String VERSION = "$version";
 }
 """)
-  }
+    }
 }
 
 compileJava.dependsOn(manageVersionClass)

--- a/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
@@ -10,25 +10,15 @@ import com.grafana.extensions.instrumentations.TestedInstrumentationsCustomizer;
 import com.grafana.extensions.resources.ResourceCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
-import java.util.HashMap;
-import java.util.Map;
 
 public class GrafanaAutoConfigCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
     autoConfiguration
-        .addPropertiesSupplier(GrafanaAutoConfigCustomizerProvider::getDefaultProperties)
+        .addPropertiesSupplier(GrafanaDistributionConfig.DEFAULTS::toConfigProperties)
         .addPropertiesCustomizer(TestedInstrumentationsCustomizer::customizeProperties)
         .addMeterProviderCustomizer(MetricsCustomizer::configure)
         .addResourceCustomizer(ResourceCustomizer::truncate);
-  }
-
-  private static Map<String, String> getDefaultProperties() {
-    HashMap<String, String> map = new HashMap<>();
-    map.put("otel.instrumentation.micrometer.base-time-unit", "s");
-    map.put("otel.instrumentation.log4j-appender.experimental-log-attributes", "true");
-    map.put("otel.instrumentation.logback-appender.experimental-log-attributes", "true");
-    return map;
   }
 }

--- a/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
@@ -10,48 +10,25 @@ import com.grafana.extensions.instrumentations.TestedInstrumentationsCustomizer;
 import com.grafana.extensions.resources.ResourceCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class GrafanaAutoConfigCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
-  // Defaults in DC notation (source of truth).
-  // Structure mirrors instrumentation/development.java in DC YAML.
-  // ConfigPropertiesBackedConfigProvider bridges these to ConfigProperties automatically.
-  static final Map<String, Map<String, String>> DC_DEFAULTS = new HashMap<>();
-
-  static {
-    DC_DEFAULTS.put("micrometer", Collections.singletonMap("base_time_unit", "s"));
-    DC_DEFAULTS.put(
-        "log4j_appender", Collections.singletonMap("experimental_log_attributes", "true"));
-    DC_DEFAULTS.put(
-        "logback_appender", Collections.singletonMap("experimental_log_attributes", "true"));
-  }
-
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
     autoConfiguration
-        .addPropertiesSupplier(GrafanaAutoConfigCustomizerProvider::getDefaultConfigProperties)
+        .addPropertiesSupplier(GrafanaAutoConfigCustomizerProvider::getDefaultProperties)
         .addPropertiesCustomizer(TestedInstrumentationsCustomizer::customizeProperties)
         .addMeterProviderCustomizer(MetricsCustomizer::configure)
         .addResourceCustomizer(ResourceCustomizer::truncate);
   }
 
-  /** Translate DC defaults to {@code otel.instrumentation.*} keys for auto-configuration. */
-  private static Map<String, String> getDefaultConfigProperties() {
+  private static Map<String, String> getDefaultProperties() {
     HashMap<String, String> map = new HashMap<>();
-    DC_DEFAULTS.forEach(
-        (instrumentation, properties) ->
-            properties.forEach(
-                (key, value) -> {
-                  String configKey =
-                      "otel.instrumentation."
-                          + instrumentation.replace('_', '-')
-                          + "."
-                          + key.replace('_', '-');
-                  map.put(configKey, value);
-                }));
+    map.put("otel.instrumentation.micrometer.base-time-unit", "s");
+    map.put("otel.instrumentation.log4j-appender.experimental-log-attributes", "true");
+    map.put("otel.instrumentation.logback-appender.experimental-log-attributes", "true");
     return map;
   }
 }

--- a/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
@@ -10,20 +10,23 @@ import com.grafana.extensions.instrumentations.TestedInstrumentationsCustomizer;
 import com.grafana.extensions.resources.ResourceCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class GrafanaAutoConfigCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
   // Defaults in DC notation (source of truth).
-  // Keys are DC paths under instrumentation/development.java.
+  // Structure mirrors instrumentation/development.java in DC YAML.
   // ConfigPropertiesBackedConfigProvider bridges these to ConfigProperties automatically.
-  static final Map<String, String> DC_DEFAULTS = new HashMap<>();
+  static final Map<String, Map<String, String>> DC_DEFAULTS = new HashMap<>();
 
   static {
-    DC_DEFAULTS.put("micrometer.base_time_unit", "s");
-    DC_DEFAULTS.put("log4j_appender.experimental_log_attributes", "true");
-    DC_DEFAULTS.put("logback_appender.experimental_log_attributes", "true");
+    DC_DEFAULTS.put("micrometer", Collections.singletonMap("base_time_unit", "s"));
+    DC_DEFAULTS.put(
+        "log4j_appender", Collections.singletonMap("experimental_log_attributes", "true"));
+    DC_DEFAULTS.put(
+        "logback_appender", Collections.singletonMap("experimental_log_attributes", "true"));
   }
 
   @Override
@@ -38,9 +41,17 @@ public class GrafanaAutoConfigCustomizerProvider implements AutoConfigurationCus
   /** Translate DC defaults to {@code otel.instrumentation.*} keys for auto-configuration. */
   private static Map<String, String> getDefaultConfigProperties() {
     HashMap<String, String> map = new HashMap<>();
-    for (Map.Entry<String, String> entry : DC_DEFAULTS.entrySet()) {
-      map.put("otel.instrumentation." + entry.getKey().replace('_', '-'), entry.getValue());
-    }
+    DC_DEFAULTS.forEach(
+        (instrumentation, properties) ->
+            properties.forEach(
+                (key, value) -> {
+                  String configKey =
+                      "otel.instrumentation."
+                          + instrumentation.replace('_', '-')
+                          + "."
+                          + key.replace('_', '-');
+                  map.put(configKey, value);
+                }));
     return map;
   }
 }

--- a/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
@@ -15,20 +15,32 @@ import java.util.Map;
 
 public class GrafanaAutoConfigCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
+  // Defaults in DC notation (source of truth).
+  // Keys are DC paths under instrumentation/development.java.
+  // ConfigPropertiesBackedConfigProvider bridges these to ConfigProperties automatically.
+  static final Map<String, String> DC_DEFAULTS = new HashMap<>();
+
+  static {
+    DC_DEFAULTS.put("micrometer.base_time_unit", "s");
+    DC_DEFAULTS.put("log4j_appender.experimental_log_attributes", "true");
+    DC_DEFAULTS.put("logback_appender.experimental_log_attributes", "true");
+  }
+
   @Override
   public void customize(AutoConfigurationCustomizer autoConfiguration) {
     autoConfiguration
-        .addPropertiesSupplier(GrafanaAutoConfigCustomizerProvider::getDefaultProperties)
+        .addPropertiesSupplier(GrafanaAutoConfigCustomizerProvider::getDefaultConfigProperties)
         .addPropertiesCustomizer(TestedInstrumentationsCustomizer::customizeProperties)
         .addMeterProviderCustomizer(MetricsCustomizer::configure)
         .addResourceCustomizer(ResourceCustomizer::truncate);
   }
 
-  private static Map<String, String> getDefaultProperties() {
+  /** Translate DC defaults to {@code otel.instrumentation.*} keys for auto-configuration. */
+  private static Map<String, String> getDefaultConfigProperties() {
     HashMap<String, String> map = new HashMap<>();
-    map.put("otel.instrumentation.micrometer.base-time-unit", "s");
-    map.put("otel.instrumentation.log4j-appender.experimental-log-attributes", "true");
-    map.put("otel.instrumentation.logback-appender.experimental-log-attributes", "true");
+    for (Map.Entry<String, String> entry : DC_DEFAULTS.entrySet()) {
+      map.put("otel.instrumentation." + entry.getKey().replace('_', '-'), entry.getValue());
+    }
     return map;
   }
 }

--- a/custom/src/main/java/com/grafana/extensions/GrafanaDeclarativeConfigurationCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaDeclarativeConfigurationCustomizerProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions;
+
+import com.grafana.extensions.resources.internal.DistroComponentProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizer;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider;
+
+public class GrafanaDeclarativeConfigurationCustomizerProvider
+    implements DeclarativeConfigurationCustomizerProvider {
+
+  @Override
+  public void customize(DeclarativeConfigurationCustomizer customizer) {
+    customizer.addModelCustomizer(
+        model -> {
+          DistroComponentProvider.addDistroResourceProvider(model);
+          return model;
+        });
+  }
+}

--- a/custom/src/main/java/com/grafana/extensions/GrafanaDeclarativeConfigurationCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaDeclarativeConfigurationCustomizerProvider.java
@@ -17,6 +17,7 @@ public class GrafanaDeclarativeConfigurationCustomizerProvider
     customizer.addModelCustomizer(
         model -> {
           DistroComponentProvider.addDistroResourceProvider(model);
+          GrafanaDistributionConfig.DEFAULTS.applyToModel(model);
           return model;
         });
   }

--- a/custom/src/main/java/com/grafana/extensions/GrafanaDistributionConfig.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaDistributionConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions;
+
+import com.grafana.extensions.config.InstrumentationDefaults;
+
+/** Shared configuration for the Grafana distribution, expressed in DC notation. */
+class GrafanaDistributionConfig {
+
+  static final InstrumentationDefaults DEFAULTS = new InstrumentationDefaults();
+
+  static {
+    DEFAULTS.getStructured("micrometer").setDefault("base_time_unit", "s");
+    DEFAULTS.getStructured("log4j_appender").setDefault("experimental_log_attributes", "true");
+    DEFAULTS.getStructured("logback_appender").setDefault("experimental_log_attributes", "true");
+  }
+
+  private GrafanaDistributionConfig() {}
+}

--- a/custom/src/main/java/com/grafana/extensions/config/InstrumentationDefaults.java
+++ b/custom/src/main/java/com/grafana/extensions/config/InstrumentationDefaults.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions.config;
+
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalInstrumentationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalLanguageSpecificInstrumentationPropertyModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Defines instrumentation defaults using DC-style structured navigation.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * InstrumentationDefaults defaults = new InstrumentationDefaults();
+ * defaults.getStructured("micrometer").setDefault("base_time_unit", "s");
+ * defaults.getStructured("log4j_appender").setDefault("experimental_log_attributes", "true");
+ *
+ * // DC mode: inject into model
+ * customizer.addModelCustomizer(model -> defaults.applyToModel(model));
+ *
+ * // Non-DC mode: translate to ConfigProperties
+ * autoConfiguration.addPropertiesSupplier(defaults::toConfigProperties);
+ * }</pre>
+ *
+ * <p>TODO: Propose as shared utility in otel-java-contrib for distros.
+ */
+public class InstrumentationDefaults {
+
+  private final Map<String, InstrumentationPropertyDefaults> instrumentations =
+      new LinkedHashMap<>();
+
+  /** Navigate to a specific instrumentation, creating it if needed. */
+  public InstrumentationPropertyDefaults getStructured(String instrumentation) {
+    return instrumentations.computeIfAbsent(
+        instrumentation, k -> new InstrumentationPropertyDefaults());
+  }
+
+  /** Translate defaults to {@code otel.instrumentation.*} keys for auto-configuration. */
+  public Map<String, String> toConfigProperties() {
+    HashMap<String, String> map = new HashMap<>();
+    instrumentations.forEach(
+        (instrumentation, properties) ->
+            properties
+                .getDefaults()
+                .forEach(
+                    (key, value) ->
+                        map.put(
+                            "otel.instrumentation."
+                                + instrumentation.replace('_', '-')
+                                + "."
+                                + key.replace('_', '-'),
+                            value)));
+    return map;
+  }
+
+  /** Apply defaults to the DC model (under instrumentation/development.java). */
+  public OpenTelemetryConfigurationModel applyToModel(OpenTelemetryConfigurationModel model) {
+    if (instrumentations.isEmpty()) {
+      return model;
+    }
+
+    ExperimentalInstrumentationModel instrumentation = model.getInstrumentationDevelopment();
+    if (instrumentation == null) {
+      instrumentation = new ExperimentalInstrumentationModel();
+      model.withInstrumentationDevelopment(instrumentation);
+    }
+    ExperimentalLanguageSpecificInstrumentationModel java = instrumentation.getJava();
+    if (java == null) {
+      java = new ExperimentalLanguageSpecificInstrumentationModel();
+      instrumentation.withJava(java);
+    }
+
+    Map<String, ExperimentalLanguageSpecificInstrumentationPropertyModel> props =
+        java.getAdditionalProperties();
+
+    for (Map.Entry<String, InstrumentationPropertyDefaults> entry : instrumentations.entrySet()) {
+      String name = entry.getKey();
+      Map<String, String> defaults = entry.getValue().getDefaults();
+
+      ExperimentalLanguageSpecificInstrumentationPropertyModel propModel = props.get(name);
+      if (propModel == null) {
+        propModel = new ExperimentalLanguageSpecificInstrumentationPropertyModel();
+        props.put(name, propModel);
+      }
+
+      // Only set defaults for properties not already present in the model
+      for (Map.Entry<String, String> defaultEntry : defaults.entrySet()) {
+        propModel
+            .getAdditionalProperties()
+            .putIfAbsent(defaultEntry.getKey(), defaultEntry.getValue());
+      }
+    }
+
+    return model;
+  }
+
+  public static class InstrumentationPropertyDefaults {
+
+    private final Map<String, String> defaults = new LinkedHashMap<>();
+
+    /** Set a default value for a property. */
+    public InstrumentationPropertyDefaults setDefault(String key, String value) {
+      defaults.put(key, value);
+      return this;
+    }
+
+    Map<String, String> getDefaults() {
+      return defaults;
+    }
+  }
+}

--- a/custom/src/main/java/com/grafana/extensions/resources/internal/DistroComponentProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/resources/internal/DistroComponentProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions.resources.internal;
+
+import com.grafana.extensions.resources.DistributionResource;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectionModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ResourceModel;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@SuppressWarnings("rawtypes")
+public class DistroComponentProvider implements ComponentProvider {
+
+  static final String GRAFANA_JAVAAGENT_DISTRIBUTION = "grafana-javaagent-distribution";
+  private static final List<String> REQUIRED_DETECTORS =
+      Collections.singletonList(GRAFANA_JAVAAGENT_DISTRIBUTION);
+
+  public static void addDistroResourceProvider(OpenTelemetryConfigurationModel model) {
+    ResourceModel resource = model.getResource();
+    if (resource == null) {
+      resource = new ResourceModel();
+      model.withResource(resource);
+    }
+    ExperimentalResourceDetectionModel detectionModel = resource.getDetectionDevelopment();
+    if (detectionModel == null) {
+      detectionModel = new ExperimentalResourceDetectionModel();
+      resource.withDetectionDevelopment(detectionModel);
+    }
+    List<ExperimentalResourceDetectorModel> detectors =
+        Objects.requireNonNull(detectionModel.getDetectors());
+    Set<String> names =
+        detectors.stream()
+            .flatMap(detector -> detector.getAdditionalProperties().keySet().stream())
+            .collect(Collectors.toSet());
+
+    for (String name : REQUIRED_DETECTORS) {
+      if (!names.contains(name)) {
+        ExperimentalResourceDetectorModel detector = new ExperimentalResourceDetectorModel();
+        detector.getAdditionalProperties().put(name, null);
+        detectors.add(detector);
+      }
+    }
+  }
+
+  @Override
+  public Class<?> getType() {
+    return Resource.class;
+  }
+
+  @Override
+  public String getName() {
+    return GRAFANA_JAVAAGENT_DISTRIBUTION;
+  }
+
+  @Override
+  public Object create(DeclarativeConfigProperties config) {
+    return DistributionResource.get();
+  }
+}

--- a/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
+++ b/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
@@ -1,0 +1,1 @@
+com.grafana.extensions.resources.internal.DistroComponentProvider

--- a/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider
+++ b/custom/src/main/resources/META-INF/services/io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfigurationCustomizerProvider
@@ -1,0 +1,1 @@
+com.grafana.extensions.GrafanaDeclarativeConfigurationCustomizerProvider

--- a/custom/src/test/java/com/grafana/extensions/config/InstrumentationDefaultsTest.java
+++ b/custom/src/test/java/com/grafana/extensions/config/InstrumentationDefaultsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InstrumentationDefaultsTest {
+
+  @Test
+  void toConfigProperties() {
+    InstrumentationDefaults defaults = new InstrumentationDefaults();
+    defaults.getStructured("micrometer").setDefault("base_time_unit", "s");
+    defaults.getStructured("log4j_appender").setDefault("experimental_log_attributes", "true");
+
+    Map<String, String> props = defaults.toConfigProperties();
+
+    assertThat(props)
+        .containsEntry("otel.instrumentation.micrometer.base-time-unit", "s")
+        .containsEntry("otel.instrumentation.log4j-appender.experimental-log-attributes", "true")
+        .hasSize(2);
+  }
+
+  @Test
+  void applyToModel() {
+    InstrumentationDefaults defaults = new InstrumentationDefaults();
+    defaults.getStructured("micrometer").setDefault("base_time_unit", "s");
+
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    defaults.applyToModel(model);
+
+    assertThat(
+            model
+                .getInstrumentationDevelopment()
+                .getJava()
+                .getAdditionalProperties()
+                .get("micrometer")
+                .getAdditionalProperties())
+        .containsEntry("base_time_unit", "s");
+  }
+
+  @Test
+  void applyToModelDoesNotOverrideExisting() {
+    InstrumentationDefaults defaults = new InstrumentationDefaults();
+    defaults.getStructured("micrometer").setDefault("base_time_unit", "s");
+
+    // Pre-populate model with a different value
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    InstrumentationDefaults existing = new InstrumentationDefaults();
+    existing.getStructured("micrometer").setDefault("base_time_unit", "ms");
+    existing.applyToModel(model);
+
+    // Apply defaults — should not override
+    defaults.applyToModel(model);
+
+    assertThat(
+            model
+                .getInstrumentationDevelopment()
+                .getJava()
+                .getAdditionalProperties()
+                .get("micrometer")
+                .getAdditionalProperties())
+        .containsEntry("base_time_unit", "ms");
+  }
+}

--- a/custom/src/test/java/com/grafana/extensions/resources/internal/DistroComponentProviderTest.java
+++ b/custom/src/test/java/com/grafana/extensions/resources/internal/DistroComponentProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions.resources.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.ExperimentalResourceDetectorModel;
+import io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel;
+import org.junit.jupiter.api.Test;
+
+class DistroComponentProviderTest {
+
+  @Test
+  void addsDetectorWhenAbsent() {
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+
+    DistroComponentProvider.addDistroResourceProvider(model);
+
+    assertThat(model.getResource().getDetectionDevelopment().getDetectors())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            d ->
+                assertThat(d.getAdditionalProperties())
+                    .containsKey(DistroComponentProvider.GRAFANA_JAVAAGENT_DISTRIBUTION));
+  }
+
+  @Test
+  void doesNotDuplicateWhenPresent() {
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    DistroComponentProvider.addDistroResourceProvider(model);
+    DistroComponentProvider.addDistroResourceProvider(model);
+
+    assertThat(model.getResource().getDetectionDevelopment().getDetectors()).hasSize(1);
+  }
+
+  @Test
+  void preservesExistingDetectors() {
+    OpenTelemetryConfigurationModel model = new OpenTelemetryConfigurationModel();
+    DistroComponentProvider.addDistroResourceProvider(model);
+
+    // Add another detector
+    ExperimentalResourceDetectorModel other = new ExperimentalResourceDetectorModel();
+    other.getAdditionalProperties().put("other-detector", null);
+    model.getResource().getDetectionDevelopment().getDetectors().add(other);
+
+    DistroComponentProvider.addDistroResourceProvider(model);
+
+    assertThat(model.getResource().getDetectionDevelopment().getDetectors()).hasSize(2);
+  }
+}


### PR DESCRIPTION
Blocked by https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/17816

## Summary

- Register the distro's resource detector via `DeclarativeConfigurationCustomizerProvider` (model customizer) and `ComponentProvider` SPIs for DC mode
- Add `InstrumentationDefaults` utility for DC-native default configuration — distro authors write `defaults.getStructured("micrometer").setDefault("base_time_unit", "s")` and the same instance serves both DC mode (model injection) and auto-config mode (`otel.instrumentation.*` translation)
- `ConfigPropertiesBackedConfigProvider` (from [open-telemetry/opentelemetry-java-instrumentation#15835](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15835)) bridges ConfigProperties to DC paths automatically

Supersedes [#1062](https://github.com/grafana/grafana-opentelemetry-java/pull/1062).

### Candidates for shared utils (otel-java-contrib)

These patterns will be needed by every distro adding DC support:

- **`InstrumentationDefaults`** — DC-native API for defining instrumentation defaults, with `applyToModel()` and `toConfigProperties()` adapters
- **`DistroComponentProvider` boilerplate** — registering a distro resource detector requires walking a null-check chain through `ResourceModel` → `ExperimentalResourceDetectionModel` → detectors list; a helper like `ModelHelper.ensureResourceDetector(model, name)` would simplify this

To be discussed in Java SIG before porting.

## Test plan

- [x] `./gradlew :custom:test` passes
- [x] `InstrumentationDefaultsTest` covers `toConfigProperties()`, `applyToModel()`, and does-not-override-existing semantics
- [ ] Smoke test with DC YAML config once upstream `ConfigPropertiesBackedConfigProvider` lands