### PR TITLE
chore: fix flint baseline lint failures

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -1,23 +1,15 @@
 {
   ".github/renovate.json5": {
-    "renovate-config-presets": [
-      "grafana/flint"
-    ]
+    "renovate-config-presets": ["grafana/flint"]
   },
   ".github/workflows/build.yml": {
-    "regex": [
-      "mise"
-    ]
+    "regex": ["mise"]
   },
   ".github/workflows/lint.yml": {
-    "regex": [
-      "mise"
-    ]
+    "regex": ["mise"]
   },
   ".github/workflows/release.yml": {
-    "regex": [
-      "mise"
-    ]
+    "regex": ["mise"]
   },
   "Dockerfile": {
     "dockerfile": [
@@ -49,19 +41,13 @@
     ]
   },
   "custom/build.gradle": {
-    "gradle": [
-      "org.owasp.dependencycheck"
-    ]
+    "gradle": ["org.owasp.dependencycheck"]
   },
   "gradle/checkstyle.gradle": {
-    "gradle": [
-      "checkstyle"
-    ]
+    "gradle": ["checkstyle"]
   },
   "gradle/wrapper/gradle-wrapper.properties": {
-    "gradle-wrapper": [
-      "gradle"
-    ]
+    "gradle-wrapper": ["gradle"]
   },
   "mise.toml": {
     "mise": [
@@ -85,9 +71,7 @@
     ]
   },
   "scripts/otel_operator/Dockerfile": {
-    "dockerfile": [
-      "busybox"
-    ]
+    "dockerfile": ["busybox"]
   },
   "smoke-tests/build.gradle": {
     "gradle": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: [
-    "config:best-practices",
-    "config:recommended",
-    "github>grafana/flint#v0.20.3",
-  ],
+  extends: ["config:best-practices", "config:recommended", "github>grafana/flint#v0.20.3"],
   platformCommit: "enabled",
   automerge: true,
   labels: ["dependencies"],

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic secret"
 # 5. Come up with a **Service Name** to identify the service, for example `cart`, and copy it into the shell command below.
 #    Use the `service.namespace` to group multiple services together.
 
-ENV OTEL_SERVICE_NAME=<Service Name>
+ENV OTEL_SERVICE_NAME="<Service Name>"
 
 # 6. Optional: add resource attributes to the shell command below:
 #    - **deployment.environment**: Name of the deployment environment, for example `staging` or `production`

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -15,7 +15,7 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 # 4. Choose a **Service Name** to identify the service (e.g. `cart`)
-ENV OTEL_SERVICE_NAME=<Service Name>
+ENV OTEL_SERVICE_NAME="<Service Name>"
 
 # 4. Add attributes to filter data (recommended):
 #    - **deployment.environment**: Name of the deployment environment (`staging` or `production`)

--- a/custom/src/test/java/com/grafana/extensions/instrumentations/TestedInstrumentationsCustomizerTest.java
+++ b/custom/src/test/java/com/grafana/extensions/instrumentations/TestedInstrumentationsCustomizerTest.java
@@ -64,8 +64,8 @@ class TestedInstrumentationsCustomizerTest {
                     Map.of(),
                     Map.of(),
                     ("Grafana OpenTelemetry Javaagent: version=%s, includeAllInstrumentations=true,"
-                            + " useTestedInstrumentations=false, includedUntestedInstrumentations=[],"
-                            + " excludedInstrumentations=[]")
+                         + " useTestedInstrumentations=false, includedUntestedInstrumentations=[],"
+                         + " excludedInstrumentations=[]")
                         .formatted(DistributionVersion.VERSION),
                     ""))),
         Arguments.of(
@@ -155,8 +155,8 @@ class TestedInstrumentationsCustomizerTest {
                         "otel.instrumentation.common.default.enabled",
                         "false"),
                     ("Grafana OpenTelemetry Javaagent: version=%s,"
-                            + " includeAllInstrumentations=false, useTestedInstrumentations=false,"
-                            + " includedUntestedInstrumentations=[play], excludedInstrumentations=[]")
+                         + " includeAllInstrumentations=false, useTestedInstrumentations=false,"
+                         + " includedUntestedInstrumentations=[play], excludedInstrumentations=[]")
                         .formatted(DistributionVersion.VERSION),
                     ""))));
   }


### PR DESCRIPTION
## Summary

- Fix google-java-format output for the instrumentation customizer test.
- Quote placeholder Dockerfile service names for hadolint.
- Apply Prettier formatting to repo config files.

Refs grafana/flint#213.

## Validation

- google-java-format
- prettier --check .
- hadolint
- push hook: mise run lint:fix (fast-only)