### PR TITLE
chore: drop obsolete setup_migration_version flint setting

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -1,6 +1,5 @@
 [settings]
 exclude = ["CHANGELOG.md", "gradlew", "gradlew.bat"]
-setup_migration_version = 2
 
 [checks.license-header]
 text = """


### PR DESCRIPTION
## Summary

- Drop `setup_migration_version = 2` from `.github/config/flint.toml`

## Why

The field is no longer read by Flint - migrations are tracked per-key now, not via a global version number. Leaving the stale value confuses readers and adds noise to `[settings]`.

## Test plan

- [ ] CI green