### PR TITLE
Add otel-sdk team as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* * @grafana/otel-sdk @zeitlinger @jaydeluca
+* @grafana/otel-sdk @zeitlinger @jaydeluca

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* @zeitlinger @jaydeluca
+* * @grafana/otel-sdk @zeitlinger @jaydeluca


### PR DESCRIPTION
Add the `otel-sdk` team as CODEOWNERS.

I've intentionally left @zeitlinger and @jaydeluca as individuals as the Java SMEs, but as they're members of the team anyway they could be removed if desired as the effect would be the same overall.
