### PR TITLE
chore: add aube and allow_builds for npm:renovate

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+aube = "latest"
 java = "temurin-25.0.1+8.0.LTS"
 node = "24.16.0"
 
@@ -13,7 +14,7 @@ google-java-format = "1.35.0"
 hadolint = "2.14.0"
 ktlint = "1.8.0"
 lychee = "0.24.2"
-"npm:renovate" = "43.150.0"
+"npm:renovate" = { version = "43.150.0", allow_builds = ["re2"] }
 rumdl = "0.1.80"
 shellcheck = "v0.11.0"
 shfmt = "v3.12.0"


### PR DESCRIPTION
Blocked by https://github.com/grafana/flint/pull/344

## Summary

- Adds `aube = "latest"` alongside `node` in `[tools]`
- Updates `npm:renovate` from a plain version string to `{ version = "...", allow_builds = ["re2"] }`

## Background

mise's npm backend installs packages with `--ignore-scripts=true`, which silently prevents renovate's `re2` dependency from downloading its native binary at install time. Without it, renovate crashes with `Cannot find module './build/Release/re2.node'` at runtime.

`aube` is a fast Node.js package manager that mise picks up automatically (default `npm.package_manager = "auto"`). It supports `allow_builds` allowlisting so `re2` can install correctly.

Tracked upstream in [jdx/mise#10237](https://github.com/jdx/mise/discussions/10237) and [grafana/flint#344](https://github.com/grafana/flint/pull/344).

## Status

Draft — waiting for [grafana/flint#344](https://github.com/grafana/flint/pull/344) to release. Once released, run `flint run --fix flint-setup` to get the pinned aube version and normalized tool ordering.

## Test plan

- [ ] `mise install` installs renovate without errors after this change
- [ ] CI passes