### PR TITLE
Update RELEASING

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ The release version will match the version specified by the `otelInstrumentation
 1. Click on the **Run workflow** button
 1. If required, enter a specific version number (e.g. `x.y.z`) in the version field. If left
    blank, the version will track the version in [`otelInstrumentationVersion`][otel-java-instrumentation-version].
-   Bugfix releases should be `x.y.z+N`, where `x.y.z` is the upstream version and `N` is the number of the "patch" for it.
+   Bugfix releases should be `x.y.z+patch.N`, where `x.y.z` is the upstream version and `N` is the number of the "patch" for it.
    This SemVer 2.0 syntax is required by the tag rules that gate permissions to publish to Google Artifact Registry.
    Note that DockerHub does not support SemVer 2.0 syntax so this approach would not work there.
 1. Wait for the workflow to complete successfully.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,9 @@ The release version will match the version specified by the `otelInstrumentation
 1. Click on the **Run workflow** button
 1. If required, enter a specific version number (e.g. `x.y.z`) in the version field. If left
    blank, the version will track the version in [`otelInstrumentationVersion`][otel-java-instrumentation-version].
-   Bugfix releases should be `x.y.z.1`, where `x.y.z` is the upstream version.
+   Bugfix releases should be `x.y.z+N`, where `x.y.z` is the upstream version and `N` is the number of the "patch" for it.
+   This SemVer 2.0 syntax is required by the tag rules that gate permissions to publish to Google Artifact Registry.
+   Note that DockerHub does not support SemVer 2.0 syntax so this approach would not work there.
 1. Wait for the workflow to complete successfully.
 1. Click the link in the workflow run summary to the untagged release created by the workflow.
 1. Click the edit button (pencil icon) at the top right of the release notes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,9 +23,9 @@ The release version will match the version specified by the `otelInstrumentation
 1. Click on the **Run workflow** button
 1. If required, enter a specific version number (e.g. `x.y.z`) in the version field. If left
    blank, the version will track the version in [`otelInstrumentationVersion`][otel-java-instrumentation-version].
-   Bugfix releases should be `x.y.z+patch.N`, where `x.y.z` is the upstream version and `N` is the number of the "patch" for it.
-   This SemVer 2.0 syntax is required by the tag rules that gate permissions to publish to Google Artifact Registry.
-   Note that DockerHub does not support SemVer 2.0 syntax so this approach would not work there.
+   Bugfix releases should be `x.y.z+patch.N`, where `x.y.z` is the upstream version and `N` is the number of the
+   "patch" for it. This SemVer 2.0 syntax is required by the tag rules that gate permissions to publish to Google
+   Artifact Registry. Note that DockerHub does not support SemVer 2.0 syntax so this approach would not work there.
 1. Wait for the workflow to complete successfully.
 1. Click the link in the workflow run summary to the untagged release created by the workflow.
 1. Click the edit button (pencil icon) at the top right of the release notes.


### PR DESCRIPTION
Update the release instructions for patches separate to upstream.

The regex that guards publishing to GAR is:

```text
refs\/heads\/(main$|master$)|refs\/tags(\/.+)?\/v(0|[1-9][0-9]*)([.](0|[1-9][0-9]*)([.](0|[1-9][0-9]*))?)?(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)([.](0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(([+])([0-9a-zA-Z-]+([.][0-9a-zA-Z-]+)*))?$
```

This prevents us from using `major.minor.patch.build` versioning, so instead we must use the metadata part of SemVer 2.0 to carry the additional information.

From testing in [regex101.com](https://regex101.com/), this seems to work:

<img width="877" height="383" alt="image" src="https://github.com/user-attachments/assets/633f1e52-0135-408a-b011-a037b310a9cb" />
