### PR TITLE
fix: preserve attribute advice for retained metrics when Data Saver is enabled

### DIFF
--- a/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
+++ b/custom/src/main/java/com/grafana/extensions/GrafanaAutoConfigCustomizerProvider.java
@@ -5,6 +5,7 @@
 
 package com.grafana.extensions;
 
+import com.grafana.extensions.filter.MetricFilter;
 import com.grafana.extensions.filter.MetricsCustomizer;
 import com.grafana.extensions.instrumentations.TestedInstrumentationsCustomizer;
 import com.grafana.extensions.resources.ResourceCustomizer;
@@ -21,6 +22,7 @@ public class GrafanaAutoConfigCustomizerProvider implements AutoConfigurationCus
         .addPropertiesSupplier(GrafanaAutoConfigCustomizerProvider::getDefaultProperties)
         .addPropertiesCustomizer(TestedInstrumentationsCustomizer::customizeProperties)
         .addMeterProviderCustomizer(MetricsCustomizer::configure)
+        .addMetricExporterCustomizer(MetricFilter::configure)
         .addResourceCustomizer(ResourceCustomizer::truncate);
   }
 

--- a/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 
 /**
  * A {@link MetricExporter} that forwards only Application Observability metrics (plus any metrics
- * created with the {@code application} meter) to the delegate and drops everything else. See
- * {@link MetricFilter} for why filtering happens here rather than through metric {@code View}s.
+ * created with the {@code application} meter) to the delegate and drops everything else. See {@link
+ * MetricFilter} for why filtering happens here rather than through metric {@code View}s.
  */
 class FilteringMetricExporter implements MetricExporter {
 

--- a/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
@@ -17,9 +17,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * A {@link MetricExporter} that only forwards Application Observability metrics to the delegate and
- * drops everything else. See {@link MetricFilter} for why filtering happens here rather than
- * through metric {@code View}s.
+ * A {@link MetricExporter} that forwards only Application Observability metrics (plus any metrics
+ * created with the {@code application} meter) to the delegate and drops everything else. See
+ * {@link MetricFilter} for why filtering happens here rather than through metric {@code View}s.
  */
 class FilteringMetricExporter implements MetricExporter {
 

--- a/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions.filter;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link MetricExporter} that only forwards Application Observability metrics to the delegate and
+ * drops everything else. See {@link MetricFilter} for why filtering happens here rather than through
+ * metric {@code View}s.
+ */
+class FilteringMetricExporter implements MetricExporter {
+
+  private final MetricExporter delegate;
+
+  FilteringMetricExporter(MetricExporter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public CompletableResultCode export(Collection<MetricData> metrics) {
+    List<MetricData> filtered =
+        metrics.stream().filter(MetricFilter::isAllowed).collect(Collectors.toList());
+    if (filtered.isEmpty()) {
+      return CompletableResultCode.ofSuccess();
+    }
+    return delegate.export(filtered);
+  }
+
+  @Override
+  public CompletableResultCode flush() {
+    return delegate.flush();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return delegate.shutdown();
+  }
+
+  @Override
+  public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+    return delegate.getAggregationTemporality(instrumentType);
+  }
+
+  @Override
+  public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
+    return delegate.getDefaultAggregation(instrumentType);
+  }
+
+  @Override
+  public MemoryMode getMemoryMode() {
+    return delegate.getMemoryMode();
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+}

--- a/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/FilteringMetricExporter.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 
 /**
  * A {@link MetricExporter} that only forwards Application Observability metrics to the delegate and
- * drops everything else. See {@link MetricFilter} for why filtering happens here rather than through
- * metric {@code View}s.
+ * drops everything else. See {@link MetricFilter} for why filtering happens here rather than
+ * through metric {@code View}s.
  */
 class FilteringMetricExporter implements MetricExporter {
 

--- a/custom/src/main/java/com/grafana/extensions/filter/MetricFilter.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/MetricFilter.java
@@ -6,41 +6,41 @@
 package com.grafana.extensions.filter;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.metrics.Aggregation;
-import io.opentelemetry.sdk.metrics.InstrumentSelector;
-import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import io.opentelemetry.sdk.metrics.View;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
 public class MetricFilter {
 
   public static final String APPLICATION_OBSERVABILITY_METRICS =
       "grafana.otel.application-observability-metrics";
 
+  static final String APPLICATION_METER_NAME = "application";
+
   private MetricFilter() {}
 
-  static void dropUnusedMetrics(SdkMeterProviderBuilder sdkMeterProviderBuilder) {
-    View allow = View.builder().build();
-
-    // allow all manually created metrics
-    sdkMeterProviderBuilder.registerView(
-        InstrumentSelector.builder().setMeterName("application").build(), allow);
-
-    // allow default metrics
-    for (String metric : DefaultMetrics.DEFAULT_METRICS) {
-      sdkMeterProviderBuilder.registerView(
-          InstrumentSelector.builder().setName(metric).build(), allow);
+  /**
+   * Wraps {@code exporter} so that, when Data Saver is enabled, only Application Observability
+   * metrics are exported and everything else is dropped.
+   *
+   * <p>Filtering happens at export time rather than through metric {@code View}s on purpose: an
+   * explicitly registered View shadows the instrument's attribute advice and the {@code
+   * MetricReader}'s {@code DefaultAggregationSelector}. Filtering the exported batch instead leaves
+   * retained instruments (notably {@code http.server.request.duration}) with their upstream bounded
+   * attribute set and default aggregation intact.
+   */
+  public static MetricExporter configure(MetricExporter exporter, ConfigProperties properties) {
+    if (properties.getBoolean(APPLICATION_OBSERVABILITY_METRICS, false)) {
+      return new FilteringMetricExporter(exporter);
     }
-
-    // drop everything else
-    sdkMeterProviderBuilder.registerView(
-        InstrumentSelector.builder().setName("*").build(),
-        View.builder().setAggregation(Aggregation.drop()).build());
+    return exporter;
   }
 
-  static void configure(
-      SdkMeterProviderBuilder sdkMeterProviderBuilder, ConfigProperties properties) {
-    if (properties.getBoolean(APPLICATION_OBSERVABILITY_METRICS, false)) {
-      dropUnusedMetrics(sdkMeterProviderBuilder);
+  static boolean isAllowed(MetricData metric) {
+    // allow all manually created metrics
+    if (APPLICATION_METER_NAME.equals(metric.getInstrumentationScopeInfo().getName())) {
+      return true;
     }
+    // allow default metrics
+    return DefaultMetrics.DEFAULT_METRICS.contains(metric.getName());
   }
 }

--- a/custom/src/main/java/com/grafana/extensions/filter/MetricFilter.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/MetricFilter.java
@@ -20,13 +20,17 @@ public class MetricFilter {
 
   /**
    * Wraps {@code exporter} so that, when Data Saver is enabled, only Application Observability
-   * metrics are exported and everything else is dropped.
+   * metrics are forwarded to the delegate exporter and everything else is filtered out.
    *
    * <p>Filtering happens at export time rather than through metric {@code View}s on purpose: an
    * explicitly registered View shadows the instrument's attribute advice and the {@code
    * MetricReader}'s {@code DefaultAggregationSelector}. Filtering the exported batch instead leaves
    * retained instruments (notably {@code http.server.request.duration}) with their upstream bounded
    * attribute set and default aggregation intact.
+   *
+   * <p>Note that disallowed instruments are still recorded and aggregated in-process by the SDK;
+   * they are only excluded from the exported batch. This does not reduce the in-process metric
+   * workload and does not suppress SDK cardinality warnings for disallowed instruments.
    */
   public static MetricExporter configure(MetricExporter exporter, ConfigProperties properties) {
     if (properties.getBoolean(APPLICATION_OBSERVABILITY_METRICS, false)) {

--- a/custom/src/main/java/com/grafana/extensions/filter/MetricsCustomizer.java
+++ b/custom/src/main/java/com/grafana/extensions/filter/MetricsCustomizer.java
@@ -17,8 +17,9 @@ public class MetricsCustomizer {
 
     ServerAddressConfig.configure(sdkMeterProviderBuilder, properties);
 
-    // must be last, because it drops all metrics not explicitly allowed
-    MetricFilter.configure(sdkMeterProviderBuilder, properties);
+    // Data Saver metric filtering is applied at export time via MetricFilter.configure, wired as a
+    // MetricExporter customizer, so that retained instruments keep their upstream attribute advice
+    // and default aggregation.
 
     return sdkMeterProviderBuilder;
   }

--- a/custom/src/test/java/com/grafana/extensions/filter/MetricFilterTest.java
+++ b/custom/src/test/java/com/grafana/extensions/filter/MetricFilterTest.java
@@ -72,7 +72,7 @@ class MetricFilterTest {
       // a manually created metric (meter named "application")
       provider.get("application").counterBuilder("my.business.metric").build().add(1);
 
-      exporter.export(reader.collectAllMetrics());
+      exporter.export(reader.collectAllMetrics()).join(10, TimeUnit.SECONDS);
     } finally {
       provider.close();
     }
@@ -106,7 +106,7 @@ class MetricFilterTest {
       DoubleHistogram histogram = meter.histogramBuilder("http.server.request.duration").build();
       histogram.record(0.15, HTTP_ATTRIBUTES);
 
-      exporter.export(reader.collectAllMetrics());
+      exporter.export(reader.collectAllMetrics()).join(10, TimeUnit.SECONDS);
     } finally {
       provider.close();
     }

--- a/custom/src/test/java/com/grafana/extensions/filter/MetricFilterTest.java
+++ b/custom/src/test/java/com/grafana/extensions/filter/MetricFilterTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Grafana Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.grafana.extensions.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class MetricFilterTest {
+
+  private static final Attributes HTTP_ATTRIBUTES =
+      Attributes.builder()
+          .put("http.route", "/api/test")
+          .put("http.request.method", "GET")
+          .put("http.response.status_code", 200)
+          .put("url.scheme", "http")
+          .build();
+
+  private static final DefaultConfigProperties DATA_SAVER_ON =
+      DefaultConfigProperties.createFromMap(
+          Map.of(MetricFilter.APPLICATION_OBSERVABILITY_METRICS, "true"));
+
+  @Test
+  void dataSaverDisabledReturnsExporterUnchanged() {
+    MetricExporter exporter = InMemoryMetricExporter.create();
+
+    MetricExporter result =
+        MetricFilter.configure(exporter, DefaultConfigProperties.createFromMap(Map.of()));
+
+    assertThat(result).isSameAs(exporter);
+  }
+
+  @Test
+  void dataSaverEnabledKeepsAllowedMetricsAndDropsOthers() {
+    InMemoryMetricExporter delegate = InMemoryMetricExporter.create();
+    MetricExporter exporter = MetricFilter.configure(delegate, DATA_SAVER_ON);
+
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    try {
+      // a default (application observability) metric
+      provider
+          .get("io.opentelemetry.tomcat-10.0")
+          .histogramBuilder("http.server.request.duration")
+          .build()
+          .record(0.15, HTTP_ATTRIBUTES);
+      // a metric that is not part of application observability
+      provider.get("custom-lib").counterBuilder("my.custom.metric").build().add(1);
+      // a manually created metric (meter named "application")
+      provider.get("application").counterBuilder("my.business.metric").build().add(1);
+
+      exporter.export(reader.collectAllMetrics());
+    } finally {
+      provider.close();
+    }
+
+    Set<String> exported =
+        delegate.getFinishedMetricItems().stream()
+            .map(MetricData::getName)
+            .collect(Collectors.toSet());
+
+    assertThat(exported)
+        .contains("http.server.request.duration", "my.business.metric")
+        .doesNotContain("my.custom.metric");
+  }
+
+  @Test
+  void dataSaverPreservesAttributesAndAggregation() {
+    // Exponential histogram is only applied when no View shadows the DefaultAggregationSelector.
+    InMemoryMetricReader reader =
+        InMemoryMetricReader.builder()
+            .setDefaultAggregationSelector(
+                DefaultAggregationSelector.getDefault()
+                    .with(InstrumentType.HISTOGRAM, Aggregation.base2ExponentialBucketHistogram()))
+            .build();
+
+    InMemoryMetricExporter delegate = InMemoryMetricExporter.create();
+    MetricExporter exporter = MetricFilter.configure(delegate, DATA_SAVER_ON);
+
+    SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    try {
+      Meter meter = provider.get("io.opentelemetry.tomcat-10.0");
+      DoubleHistogram histogram = meter.histogramBuilder("http.server.request.duration").build();
+      histogram.record(0.15, HTTP_ATTRIBUTES);
+
+      exporter.export(reader.collectAllMetrics());
+    } finally {
+      provider.close();
+    }
+
+    MetricData metric =
+        delegate.getFinishedMetricItems().stream()
+            .filter(m -> m.getName().equals("http.server.request.duration"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("http.server.request.duration was dropped"));
+
+    assertThat(metric.getType())
+        .as("Filtering at export time must not shadow the DefaultAggregationSelector")
+        .isEqualTo(MetricDataType.EXPONENTIAL_HISTOGRAM);
+
+    Set<String> attributeKeys =
+        metric.getExponentialHistogramData().getPoints().stream()
+            .flatMap(p -> p.getAttributes().asMap().keySet().stream())
+            .map(AttributeKey::getKey)
+            .collect(Collectors.toSet());
+    assertThat(attributeKeys)
+        .as("Filtering at export time must not alter the attribute set")
+        .containsExactlyInAnyOrder(
+            "http.route", "http.request.method", "http.response.status_code", "url.scheme");
+  }
+
+  @Test
+  void emptyBatchDoesNotReachDelegate() {
+    InMemoryMetricExporter delegate = InMemoryMetricExporter.create();
+    MetricExporter exporter = MetricFilter.configure(delegate, DATA_SAVER_ON);
+
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    try {
+      LongCounter counter = provider.get("custom-lib").counterBuilder("my.custom.metric").build();
+      counter.add(1);
+
+      Collection<MetricData> metrics = reader.collectAllMetrics();
+      assertThat(exporter.export(metrics).join(10, TimeUnit.SECONDS).isSuccess()).isTrue();
+    } finally {
+      provider.close();
+    }
+
+    assertThat(delegate.getFinishedMetricItems()).isEmpty();
+  }
+}


### PR DESCRIPTION
Fixes #1360

The root cause was that registering any View on `http.server.request.duration` makes `ViewRegistry.findViews` [return that view as-is](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistry.java#L123-L126), skipping [applyAdviceToDefaultView](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/internal/view/ViewRegistry.java#L152) so the upstream bounded 7-attribute advice was never applied.

Filtering at export avoids registering a view so the advice and aggregations are preserved while the unwanted metrics are dropped.

Related fix: #1243