### PR TITLE
ci: limit release jobs to required mise tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
+      # Keep artifact releases isolated from unrelated mise tools and caches.
       MISE_ENABLE_TOOLS: java
 
     concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      MISE_ENABLE_TOOLS: java
 
     concurrency:
       group: "${{ github.workflow }}-${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
-      # Keep artifact releases isolated from unrelated mise tools and caches.
+      # Artifact releases pair a focused tool allowlist with cache: false.
       MISE_ENABLE_TOOLS: java
 
     concurrency:


### PR DESCRIPTION
## What changed

- Restrict the artifact release job to the mise tools it actually requires.
- Keep mise-action caching disabled for release artifacts.

## Why

Focused release jobs should not install every development and linting tool from `mise.toml`. Apart from wasting time, unrelated tool resolution can fail and block an otherwise valid release build.

## Validation

- `mise run lint:fix`
- `git diff --check`
