### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:best-practices", "config:recommended", "github>grafana/flint#v0.22.10"],
+  extends: ["config:best-practices", "helpers:pinGitHubActionDigestsToSemver", "github>grafana/flint#v0.22.10"],
   platformCommit: "enabled",
   automerge: true,
   labels: ["dependencies"],


### PR DESCRIPTION
- Add `helpers:pinGitHubActionDigestsToSemver` to ensure major upgrades always use a full version comment.
- Remove redundant `config:recommended` ([`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices) extends it).
