### PR TITLE
fix: enforce UTF-8 resource attribute limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,8 @@ customization points in `:custom`:
   `Instrumentations.java` (controlled by
   `grafana.otel.use-tested-instrumentations` property)
 - `MetricsCustomizer` / `MetricFilter` — filters metrics
-- `ResourceCustomizer` — truncates resource attribute values (default 2048 chars)
+- `ResourceCustomizer` — truncates resource attribute values
+  (default 2048 UTF-8 bytes)
 - `DistributionVersion.java` — **auto-generated** by
   `custom/build.gradle` `manageVersionClass` task; do not
   edit manually

--- a/custom/src/main/java/com/grafana/extensions/resources/ResourceCustomizer.java
+++ b/custom/src/main/java/com/grafana/extensions/resources/ResourceCustomizer.java
@@ -18,7 +18,7 @@ public class ResourceCustomizer {
 
   @SuppressWarnings("unchecked")
   public static Resource truncate(Resource resource, ConfigProperties config) {
-    // trim all the attributes according to the config
+    // trim all string attributes to the configured UTF-8 byte limit
     int limit = config.getInt(TRUNCATE_LENGTH, 2048);
     if (limit <= 0) {
       return resource;
@@ -31,12 +31,43 @@ public class ResourceCustomizer {
             (key, value) -> {
               if (value instanceof String) {
                 String s = (String) value;
-                if (s.length() > limit) {
-                  builder.put((AttributeKey<? super String>) key, s.substring(0, limit));
+                String truncated = truncateUtf8(s, limit);
+                if (!truncated.equals(s)) {
+                  builder.put((AttributeKey<? super String>) key, truncated);
                 }
               }
             });
 
     return builder.build();
+  }
+
+  // Grafana Cloud limits resource attribute values by UTF-8 byte size, not code point count:
+  // https://grafana.com/docs/grafana-cloud/send-data/otlp/otlp-format-considerations/
+  private static String truncateUtf8(String value, int limit) {
+    int bytes = 0;
+    int index = 0;
+    while (index < value.length()) {
+      int codePoint = value.codePointAt(index);
+      int codePointBytes = utf8Length(codePoint);
+      if (codePointBytes > limit - bytes) {
+        break;
+      }
+      bytes += codePointBytes;
+      index += Character.charCount(codePoint);
+    }
+    return index == value.length() ? value : value.substring(0, index);
+  }
+
+  private static int utf8Length(int codePoint) {
+    if (codePoint <= 0x7F) {
+      return 1;
+    }
+    if (codePoint <= 0x7FF) {
+      return 2;
+    }
+    if (codePoint <= 0xFFFF) {
+      return 3;
+    }
+    return 4;
   }
 }

--- a/custom/src/main/java/com/grafana/extensions/resources/ResourceCustomizer.java
+++ b/custom/src/main/java/com/grafana/extensions/resources/ResourceCustomizer.java
@@ -53,6 +53,7 @@ public class ResourceCustomizer {
         break;
       }
       bytes += codePointBytes;
+      // Advance by UTF-16 code units; UTF-8 bytes are counted separately above.
       index += Character.charCount(codePoint);
     }
     return index == value.length() ? value : value.substring(0, index);

--- a/custom/src/test/java/com/grafana/extensions/resources/ResourceCustomizerTest.java
+++ b/custom/src/test/java/com/grafana/extensions/resources/ResourceCustomizerTest.java
@@ -19,6 +19,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class ResourceCustomizerTest {
 
+  private static final String E_ACUTE = "\u00E9";
+  private static final String GRINNING_FACE = "\uD83D\uDE00";
+
   private static final Resource RESOURCE =
       Resource.builder()
           .put("key1", "short")
@@ -34,6 +37,18 @@ class ResourceCustomizerTest {
   void truncate(String name, TestCase testCase) {
     Resource resource = ResourceCustomizer.truncate(RESOURCE, testCase.config());
     assertThat(resource).isEqualTo(testCase.want());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("utf8TestCases")
+  void truncateUtf8(String name, String value, int limit, String expected) {
+    AttributeKey<String> key = AttributeKey.stringKey("key");
+    Resource resource = Resource.builder().put(key, value).build();
+    ConfigProperties config =
+        DefaultConfigProperties.createFromMap(
+            Collections.singletonMap(ResourceCustomizer.TRUNCATE_LENGTH, Integer.toString(limit)));
+
+    assertThat(ResourceCustomizer.truncate(resource, config).getAttribute(key)).isEqualTo(expected);
   }
 
   private static Stream<Arguments> testCases() {
@@ -59,5 +74,14 @@ class ResourceCustomizerTest {
                     .build(),
                 DefaultConfigProperties.createFromMap(
                     Collections.singletonMap(ResourceCustomizer.TRUNCATE_LENGTH, "20")))));
+  }
+
+  private static Stream<Arguments> utf8TestCases() {
+    return Stream.of(
+        Arguments.of("ASCII below limit", "abc", 4, "abc"),
+        Arguments.of("ASCII above limit", "abcde", 4, "abcd"),
+        Arguments.of("multibyte characters", E_ACUTE.repeat(4), 4, E_ACUTE.repeat(2)),
+        Arguments.of("complete emoji at limit", GRINNING_FACE, 4, GRINNING_FACE),
+        Arguments.of("do not split surrogate pair", "a" + GRINNING_FACE, 2, "a"));
   }
 }


### PR DESCRIPTION
## Summary

Fix resource attribute truncation so `grafana.otel.resource.attribute.value.length.limit` is enforced using UTF-8 bytes instead of Java UTF-16 code units.

The updated truncation logic:

- Keeps values within the configured UTF-8 byte limit.
- Preserves complete Unicode code points.
- Prevents truncation from splitting emoji surrogate pairs.
- Preserves the existing behavior for ASCII values.
- Corrects the developer documentation to describe the limit as UTF-8 bytes.

Added regression coverage for ASCII, multibyte characters, and emoji boundaries.

Fixes #1389.

## Test plan

```shell
./gradlew :custom:test --tests '*ResourceCustomizerTest'
mise run lint
```