### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,4 @@ Lint tasks are sourced from [grafana/flint](https://github.com/grafana/flint).
   `github>grafana/flint` preset for mise task and tool
   version updates (see `.github/renovate.json5`)
 - `mise.toml` manages tool versions (Java, lychee) and lint tasks
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
