### PR TITLE
fix: correct shared workflow action tag comment

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Get GitHub token
         id: get-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
           github_app: grafana-otel-bot
           permission_set: default


### PR DESCRIPTION
## What changed

Correct the SHA comment for `create-github-app-token` from `# v0.2.2` to `# create-github-app-token/v0.2.2`.

## Why

The bare version comment omits the shared-workflows monorepo component name, which prevents Renovate from identifying the correct tag namespace and can cause lookup failures. The pinned SHA was verified against `create-github-app-token/v0.2.2`.

## Validation

- `mise run lint:fix`
- `mise run lint`
- `actionlint .github/workflows/publish-release.yml`

Related to grafana/shared-workflows#2255
