### PR TITLE
chore: validate Renovate GitHub Actions dependencies

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -11,4 +11,4 @@ text = """
 patterns = ["**/*.java", "**/*.kt"]
 
 [checks.renovate-deps]
-exclude_managers = ["github-actions", "github-runners"]
+exclude_managers = ["github-runners"]

--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -5,3 +5,8 @@ max_concurrency = 4
 include_fragments = "anchor-only"
 
 base_url = "https://github.com/grafana/grafana-opentelemetry-java/blob/main/"
+
+exclude = [
+  # Private Slack channel links return 403 to unauthenticated link checkers.
+  "^https://grafana\\.slack\\.com/",
+]

--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -1,5 +1,9 @@
 {
   "meta": {
+    "grafana/shared-workflows": {
+      "packageName": "grafana/shared-workflows",
+      "datasource": "github-digest"
+    },
     "io.opentelemetry.javaagent:opentelemetry-javaagent": {
       "packageName": "io.opentelemetry.javaagent:opentelemetry-javaagent",
       "datasource": "maven"
@@ -12,18 +16,41 @@
       ]
     },
     ".github/workflows/build.yml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/checkout",
+        "jdx/mise",
+        "jdx/mise-action"
       ]
     },
     ".github/workflows/lint.yml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/checkout",
+        "jdx/mise",
+        "jdx/mise-action",
+        "ubuntu"
+      ]
+    },
+    ".github/workflows/publish-release.yml": {
+      "github-actions": [
+        "actions/checkout",
+        "grafana/shared-workflows",
+        "ubuntu"
       ]
     },
     ".github/workflows/release.yml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/attest",
+        "actions/checkout",
+        "grafana/shared-workflows",
+        "jdx/mise",
+        "jdx/mise-action",
+        "ubuntu"
+      ]
+    },
+    ".github/workflows/scheduled-release.yml": {
+      "github-actions": [
+        "actions/checkout",
+        "ubuntu"
       ]
     },
     "Dockerfile": {
@@ -107,6 +134,30 @@
         "org.awaitility:awaitility",
         "org.testcontainers:testcontainers"
       ]
+    }
+  },
+  "actionMeta": {
+    "actions/attest": {
+      "packageName": "actions/attest",
+      "refKind": "version-tag"
+    },
+    "actions/checkout": {
+      "packageName": "actions/checkout",
+      "refKind": "version-tag"
+    },
+    "grafana/shared-workflows/actions/create-github-app-token": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "version-tag",
+      "compatibility": "create-github-app-token"
+    },
+    "grafana/shared-workflows/actions/docker-build-push-image": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "version-tag",
+      "compatibility": "docker-build-push-image"
+    },
+    "jdx/mise-action": {
+      "packageName": "jdx/mise-action",
+      "refKind": "version-tag"
     }
   }
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:best-practices", "helpers:pinGitHubActionDigestsToSemver", "github>grafana/flint#v0.22.10"],
+  extends: ["config:best-practices", "helpers:pinGitHubActionDigestsToSemver", "github>grafana/flint#v0.22.11"],
   platformCommit: "enabled",
   automerge: true,
   labels: ["dependencies"],

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ node = "24.19.0"
 
 # Linters
 actionlint = "1.7.12"
-"aqua:grafana/flint" = "0.22.10"
+"aqua:grafana/flint" = "0.22.11"
 "aqua:jonwiggins/xmloxide" = "0.5.0"
 "aqua:owenlamont/ryl" = "0.21.0"
 biome = "2.5.8"


### PR DESCRIPTION
## Summary

- update Flint to v0.22.11
- enable GitHub Actions coverage in the Renovate dependency snapshot
- regenerate the tracked-dependencies snapshot
- exclude private Slack channel URLs from lychee because unauthenticated checks return 403

## Verification

- `mise run lint:fix`
- `mise run lint`
- `git diff --check`

Relates https://github.com/grafana/shared-workflows/issues/2255